### PR TITLE
Spotters rafg

### DIFF
--- a/tests/io/test_spotter.py
+++ b/tests/io/test_spotter.py
@@ -3,27 +3,32 @@ import shutil
 import pytest
 from tempfile import mkdtemp
 
-from wavespectra import read_triaxys
+from wavespectra import read_spotter
+from wavespectra.input.spotter import Spotter
 from wavespectra.core.attributes import attrs
 
 FILES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../sample_files")
 
 
-class Spotter(object):
-    """Test parameters from 1D and 2D spectra from TRIAXYS are consistent."""
+class TestSpotter:
+    """Test parameters spotter reader."""
 
     @classmethod
     def setup_class(self):
         """Setup class."""
-        self.tmp_dir = mkdtemp()
-        self.ds_1d = read_triaxys(os.path.join(FILES_DIR, "triaxys.NONDIRSPEC"))
-        self.ds_2d = read_triaxys(os.path.join(FILES_DIR, "triaxys.DIRSPEC"))
+        self.spot = Spotter(os.path.join(FILES_DIR, "spotter_20180214.json"))
+        self.dset = self.spot.run()
 
-    @classmethod
-    def teardown_class(self):
-        shutil.rmtree(self.tmp_dir)
-
-    def test_hs(self):
-        assert self.ds_1d.spec.hs().values == pytest.approx(
-            self.ds_2d.spec.hs().values, rel=0.01
-        )
+    @pytest.mark.parametrize(
+        "wavespectra_name, spotter_name, kwargs",
+        [
+            ("hs", "significantWaveHeight", {}),
+            ("tp", "peakPeriod", {"smooth": False}),
+            ("tm01", "meanPeriod", {}),
+        ],
+    )
+    def test_stats(self, wavespectra_name, spotter_name, kwargs):
+        """Assert that stat calculated from wavespectra matches the one read from spotter."""
+        wavespectra = getattr(self.dset.spec, wavespectra_name)(**kwargs).values
+        spotter = getattr(self.spot, spotter_name)
+        assert wavespectra == pytest.approx(spotter, rel=1e-1)

--- a/wavespectra/input/spotter.py
+++ b/wavespectra/input/spotter.py
@@ -6,6 +6,7 @@ Functions:
 
 """
 import os
+import copy
 import glob
 import datetime
 import warnings
@@ -13,31 +14,28 @@ import pandas as pd
 import xarray as xr
 import numpy as np
 import json
+from dateutil.parser import parse
+
+from wavespectra.specdataset import SpecDataset
+from wavespectra.core.attributes import attrs, set_spec_attributes
 
 
-def test(filename):
-    with open(filename) as json_file:
-        data = json.load(json_file)
-    return data
-
-def read_spotter(filename, dirorder=True, as_site=None):
+def read_spotter(filename):
     """Read Spectra from spotter JSON file.
 
     Args:
-        - dirorder (bool): If True reorder spectra so that directions are
-          sorted.
-        - as_site (bool): If True locations are defined by 1D site dimension.
+        - filename (list, str): File name or file glob specifying spotter files to read.
 
     Returns:
         - dset (SpecDataset): spectra dataset object read from file.
 
     """
-
     spot = Spotter(filename)
-    spot.run()
-    return spot.dset
+    dset = spot.run()
+    return dset
 
-class Spotter(object):
+
+class Spotter:
     def __init__(self, filename_or_fileglob, toff=0):
         """Read wave spectra file from TRIAXYS buoy.
 
@@ -53,104 +51,129 @@ class Spotter(object):
         Remark:
             - frequencies and directions from first file are used as reference
               to interpolate spectra from other files in case they differ.
+              In fact interpolation is still not implemented here, code will break
+              if spectral coordinates are different.
 
         """
         self._filename_or_fileglob = filename_or_fileglob
         self.toff = toff
-        self.stream = None
-        self.is_dir = None
-        self.time_list = []
-        self.spec_list = []
-        self.header_keys = header_keys = [
-            "is_triaxys",
-            "is_dir",
-            "time",
-            "nf",
-            "f0",
-            "df",
-            "fmin",
-            "fmax",
-            "ddir",
-        ]
 
     def run(self):
-        for ind, self.filename in enumerate(self.filenames):
-            self.load()
-            if ind == 0:
-                try:
-                    self.spotterId = self.data['data']['spotterId']
-                except Exception as e:
-                    raise IOError("Not a Spotter Spectra file.")
-                self.freqs = self.data['data']['frequencyData'][0]['frequency']
-                self.dirs = self.data['data']['frequencyData'][0]['direction']
-                self.interp_freq = copy.deepcopy(self.freqs)
-                self.interp_dir = copy.deepcopy(self.dirs)
-            self.read_data()
-        self.construct_dataset()
+        """Returns wave spectra dataset from one or more spotter files."""
+        dsets = []
+        for self.filename in self.filenames:
+            self._load_json()
+            self._set_arrays_from_json()
+            dsets.append(self._construct_dataset())
+        # Ensuring spectral coordinates are the same across files, interpolation needs to be implemented
+        if not self._is_unique([dset.freq.values for dset in dsets]):
+            raise NotImplementedError(
+                "Varying frequency arrays between spotter files not yet supported."
+            )
+        if not self._is_unique([dset.dir.values for dset in dsets]):
+            raise NotImplementedError(
+                "Varying direction arrays between spotter files not yet supported."
+            )
+        # Concatenating datasets from multiple files
+        self.dset = xr.concat(dsets, dim="time")
+        return self.dset
 
-    def read_data(self):
-        try:
-            self.spec_data = np.zeros((len(self.freqs), len(self.dirs)))
-            for i in range(self.header.get("nf")):
-                row = list(map(float, self.stream.readline().replace(",", " ").split()))
-                if self.header.get("is_dir"):
-                    self.spec_data[i, :] = row
-                else:
-                    self.spec_data[i, :] = row[-1]
-            self._append_spectrum()
-        except ValueError as err:
-            raise ValueError("Cannot read {}:\n{}".format(self.filename, err))
+    def _is_unique(self, arrays):
+        """Returns True if all iterators in arrays are the same."""
+        if len(set(tuple(array) for array in arrays)) == 1:
+            return True
+        else:
+            return False
 
-    def load(self):
+    def _set_arrays_from_json(self):
+        """Set spectra attributes from arrays in json blob."""
+        # Spectra
+        keys = self.data["data"]["frequencyData"][0].keys()
+        for key in keys:
+            setattr(
+                self,
+                key,
+                [sample[key] for sample in self.data["data"]["frequencyData"]],
+            )
+        # Keep here only for checking - timestamps seem to differ
+        self.timestamp_spec = self.timestamp
+        self.latitude_spec = self.latitude
+        self.longitude_spec = self.longitude
+        # Parameters
+        if "waves" in self.data["data"]:
+            keys = self.data["data"]["waves"][0].keys()
+            for key in keys:
+                setattr(
+                    self, key, [sample[key] for sample in self.data["data"]["waves"]]
+                )
+        # Keep here only for checking - timestamps seem to differ
+        self.timestamp_param = self.timestamp
+        self.latitude_param = self.latitude
+        self.longitude_param = self.longitude
+
+    def _construct_dataset(self):
+        """Construct wavespectra dataset."""
+        self.dset = xr.DataArray(
+            data=self.efth, coords=self.coords, dims=self.dims, name=attrs.SPECNAME
+        ).to_dataset()
+        self.dset[attrs.LATNAME] = xr.DataArray(
+            data=self.latitude, coords={"time": self.dset.time}, dims=("time")
+        )
+        self.dset[attrs.LONNAME] = xr.DataArray(
+            data=self.longitude, coords={"time": self.dset.time}, dims=("time")
+        )
+        set_spec_attributes(self.dset)
+        return self.dset
+
+    def _load_json(self):
+        """Load data from json blob."""
         with open(self.filename) as json_file:
             self.data = json.load(json_file)
+        try:
+            self.data["data"]["spotterId"]
+        except KeyError:
+            raise IOError("Not a Spotter Spectra file: {}".format(self.filename))
 
-    def construct_dataset(self):
-        self.dset = xr.DataArray(
-            data=self.spec_list, coords=self.coords, dims=self.dims, name=attrs.SPECNAME
-        ).to_dataset()
-        set_spec_attributes(self.dset)
-        if not self.is_dir:
-            self.dset = self.dset.isel(drop=True, **{attrs.DIRNAME: 0})
-            self.dset[attrs.SPECNAME].attrs.update(units="m^{2}.s")
+    @property
+    def time(self):
+        """The time coordinate values."""
+        return [
+            parse(time).replace(tzinfo=None) - datetime.timedelta(hours=self.toff)
+            for time in self.timestamp
+        ]
 
-    def open(self):
-        self.stream = open(self.filename, "r")
+    @property
+    def efth(self):
+        """The Variance density data values."""
+        return [np.expand_dims(varden, axis=1) for varden in self.varianceDensity]
 
-    def close(self):
-        if self.stream and not self.stream.closed:
-            self.stream.close()
+    @property
+    def freq(self):
+        """The frequency coordinate values."""
+        if not self._is_unique(self.frequency):
+            raise NotImplementedError(
+                "Varying frequency arrays in single file not yet supported."
+            )
+        return self.frequency[0]
+
+    @property
+    def dir(self):
+        """The direction coordinate values, currently set to [0.] for 1D spectra."""
+        return [0.0]
 
     @property
     def dims(self):
+        """The dataset dimensions."""
         return (attrs.TIMENAME, attrs.FREQNAME, attrs.DIRNAME)
 
     @property
     def coords(self):
-        _coords = OrderedDict(
-            (
-                (attrs.TIMENAME, self.time_list),
-                (attrs.FREQNAME, self.interp_freq),
-                (attrs.DIRNAME, self.interp_dir),
-            )
-        )
-        return _coords
-
-    @property
-    def dirs(self):
-        ddir = self.header.get("ddir")
-        if ddir:
-            return list(np.arange(0.0, 360.0 + ddir, ddir))
-        else:
-            return [0.0]
-
-    @property
-    def freqs(self):
-        try:
-            f0, df, nf = self.header["f0"], self.header["df"], self.header["nf"]
-            return list(np.arange(f0, f0 + df * nf, df))
-        except Exception as exc:
-            raise IOError("Not enough info to parse frequencies:\n{}".format(exc))
+        """The dataset coordinates."""
+        return {
+            attrs.TIMENAME: self.time,
+            attrs.FREQNAME: self.freq,
+            attrs.DIRNAME: self.dir,
+        }
 
     @property
     def filenames(self):
@@ -163,4 +186,6 @@ class Spotter(object):
         return filenames
 
 
-data = read_spotter('../../tests/sample_files/spotter_20180214.json')
+if __name__ == "__main__":
+    filename = "../../tests/sample_files/spotter_20180214.json"
+    dset = read_spotter(filename)


### PR DESCRIPTION
This code should be working to read spotter as 1D spectra. In order to make it read 2D spectra we only need applying the fourier coefficients to construct efth, within the [efth](https://github.com/wavespectra/wavespectra/blob/spotters_rafg/wavespectra/input/spotter.py#L145-L148) property, and change the [dir](https://github.com/wavespectra/wavespectra/blob/spotters_rafg/wavespectra/input/spotter.py#L159-L162) property to return the real directions.

Spectra interpolation is not supported yet. If spectra within a file (not the case in the testing one), or spectra across files have different freq/dir, the code will raise an exception.

The testing is currently checking that some stats calculated from wavespectra are similar to those read from spotter file. Note that spotter seems to calculate `peakPeriod` with no smoothing, and `meanPeriod` seems to correspond to `tm01`.

# Warning
The test file has inconsistent times between spectra and parameters - the latter is shifted forward 1h. Currently times are taken from the parameters to build the dataset. These times should be the same, we need checking if this is happening in the test file only, or in all spotter files.

# Warning 2
This branch is probably not mergeable, it is 532 commits ahead of master - probably due to the history rewriting done recently.
