### PR TITLE
Convert ERA5 spectra to standard direction

### DIFF
--- a/wavespectra/input/era5.py
+++ b/wavespectra/input/era5.py
@@ -4,7 +4,7 @@ import numpy as np
 from wavespectra.input.netcdf import read_netcdf
 
 
-def read_era5(filename_or_fileglob, chunks={}, freqs=None, dirs=None):
+def read_era5(filename_or_fileglob, chunks={}, freqs=None, dirs=None, convention='coming-from'):
     """Read Spectra from ECMWF ERA5 netCDF format.
 
     Args:
@@ -15,6 +15,7 @@ def read_era5(filename_or_fileglob, chunks={}, freqs=None, dirs=None):
           xr.open_mfdataset documentation).
         - freqs (list): list of frequencies. By default use all 30 ERA5 frequencies.
         - dirs (list): list of directions. By default use all 24 ERA5 directions.
+        - convention (string): direction convention, either 'coming-from' (standard in wavespectra library) or 'going-to' (standard in ERA5 data)
 
     Returns:
         - dset (SpecDataset): spectra dataset object read from netcdf file.
@@ -25,7 +26,13 @@ def read_era5(filename_or_fileglob, chunks={}, freqs=None, dirs=None):
 
     """
     default_freqs = np.full(30, 0.03453) * (1.1 ** np.arange(0, 30))
-    default_dirs = direction = np.arange(7.5, 352.5 + 15, 15)
+    
+    if convention == 'coming-from':
+        default_dirs = direction = (np.arange(7.5, 352.5 + 15, 15) + 180) % 360
+    elif convention == 'going-to':
+        default_dirs = direction = np.arange(7.5, 352.5 + 15, 15)
+    else:
+        raise ValueError("Set convention to 'coming-from' or 'going-to'.")
 
     dset = read_netcdf(
         filename_or_fileglob,

--- a/wavespectra/input/era5.py
+++ b/wavespectra/input/era5.py
@@ -4,7 +4,7 @@ import numpy as np
 from wavespectra.input.netcdf import read_netcdf
 
 
-def read_era5(filename_or_fileglob, chunks={}, freqs=None, dirs=None, convention='coming-from'):
+def read_era5(filename_or_fileglob, chunks={}, freqs=None, dirs=None):
     """Read Spectra from ECMWF ERA5 netCDF format.
 
     Args:
@@ -15,7 +15,6 @@ def read_era5(filename_or_fileglob, chunks={}, freqs=None, dirs=None, convention
           xr.open_mfdataset documentation).
         - freqs (list): list of frequencies. By default use all 30 ERA5 frequencies.
         - dirs (list): list of directions. By default use all 24 ERA5 directions.
-        - convention (string): direction convention, either 'coming-from' (standard in wavespectra library) or 'going-to' (standard in ERA5 data)
 
     Returns:
         - dset (SpecDataset): spectra dataset object read from netcdf file.
@@ -26,13 +25,7 @@ def read_era5(filename_or_fileglob, chunks={}, freqs=None, dirs=None, convention
 
     """
     default_freqs = np.full(30, 0.03453) * (1.1 ** np.arange(0, 30))
-    
-    if convention == 'coming-from':
-        default_dirs = direction = (np.arange(7.5, 352.5 + 15, 15) + 180) % 360
-    elif convention == 'going-to':
-        default_dirs = direction = np.arange(7.5, 352.5 + 15, 15)
-    else:
-        raise ValueError("Set convention to 'coming-from' or 'going-to'.")
+    default_dirs = direction = (np.arange(7.5, 352.5 + 15, 15) + 180) % 360
 
     dset = read_netcdf(
         filename_or_fileglob,


### PR DESCRIPTION
ERA5 spectra by default use the 'going-to' convention for direction. This sets the default behaviour to be converting this to the wavespectra default of 'coming-from', but leaves the option to use 'going-to' if required.

I don't know if using 'going-to' will have any affect on other library functionality, if so perhaps 'coming-from' should simply be enforced, or a warning should be raised? I put in the option primarily so that I could maintain backwards compatibility with how I've been using it the last couple of months before I noticed that the standard for this library was 'coming-from'