### PR TITLE
Change m^2 Hz / rad to /deg

### DIFF
--- a/wavespectra/input/era5.py
+++ b/wavespectra/input/era5.py
@@ -40,7 +40,7 @@ def read_era5(filename_or_fileglob, chunks={}, freqs=None, dirs=None):
     )
 
     # Convert ERA5 format to wavespectra format
-    dset = 10 ** dset
+    dset = 10 ** dset * np.pi / 180
     dset = dset.fillna(0)
 
     dset[attrs.FREQNAME] = freqs if freqs else default_freqs


### PR DESCRIPTION
Turns out I never really checked the conventions of this library at all when I made this reader because I wasn't using any internal functions except plot, didn't notice till I actually had to write-up results from using it! Sorry about that, I should pay more attention!

Should all match now, Hz, degrees, m^2 Hz / degree