### PR TITLE
Added orcaflex export function

### DIFF
--- a/docs/io-output.rst
+++ b/docs/io-output.rst
@@ -33,3 +33,5 @@ These output functions are currently available as methods of :py:class:`~wavespe
     SpecDataset.to_swan
     SpecDataset.to_octopus
     SpecDataset.to_json
+    SpecDataset.to_orcaflex
+

--- a/tests/io/test_to_orcaflex.py
+++ b/tests/io/test_to_orcaflex.py
@@ -1,0 +1,70 @@
+import os
+import shutil
+import pytest
+from tempfile import mkdtemp
+
+from wavespectra import read_triaxys
+from wavespectra.core.attributes import attrs
+
+FILES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../sample_files")
+
+class TestToOrcaflex(object):
+    """Test writing a spectrum to orcaflex. Test will only run if the orcaflex API can be used to create an new model.
+    If not then the test will not run but will pass"""
+
+    @classmethod
+    def setup_class(self):
+        """Setup class."""
+        self.example = read_triaxys(os.path.join(FILES_DIR, "triaxys.DIRSPEC")).isel(time=0)
+
+    def test_write_to_orcaflex(self):
+
+        try:
+            import OrcFxAPI
+            m = OrcFxAPI.Model()
+        except:
+            print("Orcaflex test skipped because no license or no api")
+            return
+
+        self.example.spec.to_orcaflex(m)
+
+    def test_compare_spectra(self):
+
+        import matplotlib.pyplot as plt
+
+
+        try:
+            import OrcFxAPI
+            m = OrcFxAPI.Model()
+        except:
+            print("Orcaflex test skipped because no license or no api")
+            return
+
+        self.example.spec.to_orcaflex(m)
+        m.general.StageDuration[1]=10800 # 3 hours of simulations
+        m.RunSimulation()
+
+        t = m.general.TimeHistory('Time')
+        e = m.environment.TimeHistory('Elevation', None, objectExtra=OrcFxAPI.oeEnvironment(0,0,0))
+
+        plt.plot(t[1000:2000],e[1000:2000], linewidth=0.5)
+        plt.show()
+
+        from scipy.signal import welch, periodogram
+        dt = t[1] - t[0]
+        f, p = welch(e, 1/dt)
+        plt.plot(f,p, label = 'welch')
+
+        self.example.spec.oned().plot(label = 'source spectrun')
+        plt.legend()
+        plt.show()
+
+        plt.figure()
+        self.example.spec.plot()
+
+
+
+
+
+
+

--- a/tests/io/test_to_orcaflex.py
+++ b/tests/io/test_to_orcaflex.py
@@ -2,11 +2,15 @@ import os
 import shutil
 import pytest
 from tempfile import mkdtemp
+import xarray as xr
+import numpy as np
 
 from wavespectra import read_triaxys
 from wavespectra.core.attributes import attrs
+from wavespectra.construct import ochihubble
 
 FILES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../sample_files")
+
 
 class TestToOrcaflex(object):
     """Test writing a spectrum to orcaflex. Test will only run if the orcaflex API can be used to create an new model.
@@ -15,56 +19,84 @@ class TestToOrcaflex(object):
     @classmethod
     def setup_class(self):
         """Setup class."""
-        self.example = read_triaxys(os.path.join(FILES_DIR, "triaxys.DIRSPEC")).isel(time=0)
+
+        # dataset with time
+        self.example_single_time = read_triaxys(
+            os.path.join(FILES_DIR, "triaxys.DIRSPEC")
+        )
+
+        # dataset without time
+        # resampled to lower resolution for quicker run
+        self.example = self.example_single_time.isel(time=0)
+        self.example = self.example.interp(dir=np.linspace(0, 360, 19))
+
+        # dataset with two times, to verify export error
+        one_day_later = self.example_single_time.copy()
+        one_day_later["time"] = one_day_later.time + np.timedelta64(1, "D")
+        self.bad_example = xr.concat(
+            [self.example_single_time, one_day_later], dim="time"
+        )
 
     def test_write_to_orcaflex(self):
 
         try:
             import OrcFxAPI
+
             m = OrcFxAPI.Model()
         except:
             print("Orcaflex test skipped because no license or no api")
             return
 
         self.example.spec.to_orcaflex(m)
+
+    def test_throw_error_for_multiple_spectra_inpput(self):
+        with pytest.raises(ValueError):
+            self.bad_example.spec.to_orcaflex(None)
+
+    def test_example_single_time(self):
+        try:
+            import OrcFxAPI
+
+            m = OrcFxAPI.Model()
+        except:
+            print("Orcaflex test skipped because no license or no api")
+            return
+
+        self.example_single_time.spec.to_orcaflex(m)
 
     def test_compare_spectra(self):
 
         import matplotlib.pyplot as plt
 
-
         try:
             import OrcFxAPI
+
             m = OrcFxAPI.Model()
         except:
             print("Orcaflex test skipped because no license or no api")
             return
 
         self.example.spec.to_orcaflex(m)
-        m.general.StageDuration[1]=10800 # 3 hours of simulations
+        m.general.StageDuration[1] = 10800  # 3 hours of simulations
         m.RunSimulation()
 
-        t = m.general.TimeHistory('Time')
-        e = m.environment.TimeHistory('Elevation', None, objectExtra=OrcFxAPI.oeEnvironment(0,0,0))
+        t = m.general.TimeHistory("Time")
+        e = m.environment.TimeHistory(
+            "Elevation", None, objectExtra=OrcFxAPI.oeEnvironment(0, 0, 0)
+        )
 
-        plt.plot(t[1000:2000],e[1000:2000], linewidth=0.5)
+        plt.plot(t[1000:2000], e[1000:2000], linewidth=0.5)
         plt.show()
 
         from scipy.signal import welch, periodogram
-        dt = t[1] - t[0]
-        f, p = welch(e, 1/dt)
-        plt.plot(f,p, label = 'welch')
 
-        self.example.spec.oned().plot(label = 'source spectrun')
+        dt = t[1] - t[0]
+        f, p = welch(e, 1 / dt)
+        plt.plot(f, p, label="welch")
+
+        self.example.spec.oned().plot(label="source spectrun")
         plt.legend()
         plt.show()
 
         plt.figure()
         self.example.spec.plot()
-
-
-
-
-
-
-

--- a/wavespectra/output/orcaflex.py
+++ b/wavespectra/output/orcaflex.py
@@ -1,7 +1,8 @@
 """Orcaflex output plugin - using orcaflex API."""
 import numpy as np
 
-def to_orcaflex(self, model, minEnergy = 1e-6):
+
+def to_orcaflex(self, model, minEnergy=1e-6):
     """Writes the spectrum to an Orcaflex model
 
     Uses the orcaflex API (OrcFxAPI) to set the wave-data of the provided orcaflex model.
@@ -10,12 +11,16 @@ def to_orcaflex(self, model, minEnergy = 1e-6):
     - Orcaflex global X  = Towards East
     - Orcaflex global Y  = Towards North
 
-    This function creates a wave-train using a user-defines spectrum for each of the directions in this spectrum.
+    This function creates a wave-train for each of the directions in this spectrum using a user-defined spectrum.
 
     Calculation of wave-components in orcaflex is computationally expensive. To save computational time:
     1. Use the minEnergy parameter of this function to define a treshold for the amount of energy in a wave-train.
     2. In orcaflex itself: limit the amount of wave-components
     3. Before exporting: regrid the spectrum to a lower amount of directions.
+
+    Orcaflex theory:
+    - https://www.orcina.com/webhelp/OrcaFlex/Content/html/Wavetheory.htm
+    - https://www.orcina.com/webhelp/OrcaFlex/Content/html/Directionconventions.htm
 
     Example:
         >>> from OrcFxAPI import *
@@ -31,6 +36,8 @@ def to_orcaflex(self, model, minEnergy = 1e-6):
 
     Note:
         - an Orcaflex license is required to work with the orcaflex API.
+        - Only 2D spectra E(f,d) are currently supported.
+        - The DataArray should contain only a single spectrum. Hint: first_spetrum = spectra.isel(time=0)
 
     """
 
@@ -39,36 +46,44 @@ def to_orcaflex(self, model, minEnergy = 1e-6):
 
     ddir = self.dd
 
+    # verify what all coordinates other than dir and freq are one
+    if not np.prod(self.efth.shape) == len(dirs) * len(freqs):
+        raise ValueError(
+            "The DataArray should contain only a single spectrum.\nHint: first_spetrum = spectra.isel(time=0)"
+        )
+
     nTrains = 0
-    env = model.environment  #alias
+    env = model.environment  # alias
 
     for dir in dirs:
-        e = self.efth.sel(dict(dir=dir))
+        e = self.efth.sel(dict(dir=dir)).values.flatten()
 
         E = ddir * e
 
         if np.sum(E) <= minEnergy:
             continue
 
-        nTrains+=1
+        nTrains += 1
 
         env.NumberOfWaveTrains = nTrains
-        env.SelectedWaveTrainIndex = nTrains -1 # zero-based = f'Wave{nTrains}'
-        env.WaveDirection = np.mod(90-dir + 180, 360) # convert from coming from to going to and from compass to ofx
-        env.WaveType = 'User Defined Spectrum'
+        env.SelectedWaveTrainIndex = nTrains - 1  # zero-based = f'Wave{nTrains}'
+        env.WaveDirection = np.mod(
+            90 - dir + 180, 360
+        )  # convert from coming from to going to and from compass to ofx
+        env.WaveType = "User Defined Spectrum"
         env.WaveNumberOfSpectralDirections = 1
 
         # interior points in the spectrum with zero energy are not allowed by orcaflex
-        iFirst = np.where(E>0)[0][0]
-        iLast = np.where(E>0)[0][-1]
+        iFirst = np.where(E > 0)[0][0]
+        iLast = np.where(E > 0)[0][-1]
 
         for i in range(iFirst, iLast):
-            if E[i]<1e-10:
+            if E[i] < 1e-10:
                 E[i] = 1e-10
 
         if iFirst > 0:
-            iFirst -=1
-        if iLast < len(E)-2:
+            iFirst -= 1
+        if iLast < len(E) - 2:
             iLast += 1
 
         env.WaveNumberOfUserSpectralPoints = len(E[iFirst:iLast])
@@ -76,7 +91,6 @@ def to_orcaflex(self, model, minEnergy = 1e-6):
         env.WaveSpectrumFrequency = freqs[iFirst:iLast]  # convert o rad/s
 
     if nTrains == 0:
-        raise ValueError("No data exported, no directions with more than the minimum amount of energy")
-
-
-
+        raise ValueError(
+            "No data exported, no directions with more than the minimum amount of energy"
+        )

--- a/wavespectra/output/orcaflex.py
+++ b/wavespectra/output/orcaflex.py
@@ -1,0 +1,82 @@
+"""Orcaflex output plugin - using orcaflex API."""
+import numpy as np
+
+def to_orcaflex(self, model, minEnergy = 1e-6):
+    """Writes the spectrum to an Orcaflex model
+
+    Uses the orcaflex API (OrcFxAPI) to set the wave-data of the provided orcaflex model.
+
+    The axis system conversion used is:
+    - Orcaflex global X  = Towards East
+    - Orcaflex global Y  = Towards North
+
+    This function creates a wave-train using a user-defines spectrum for each of the directions in this spectrum.
+
+    Calculation of wave-components in orcaflex is computationally expensive. To save computational time:
+    1. Use the minEnergy parameter of this function to define a treshold for the amount of energy in a wave-train.
+    2. In orcaflex itself: limit the amount of wave-components
+    3. Before exporting: regrid the spectrum to a lower amount of directions.
+
+    Example:
+        >>> from OrcFxAPI import *
+        >>> from wavespectra import read_triaxys
+        >>> m = Model()
+        >>> spectrum = read_triaxys("triaxys.DIRSPEC")).isel(time=0)  # get only the fist spectrum in time
+        >>> spectrum.spec.to_orcaflex(m)
+
+
+    Args:
+        - model : orcaflex model (OrcFxAPI.model instance)
+        - minEnergy [1e-6] : threshold for minimum sum of energy in a direction before it is exported
+
+    Note:
+        - an Orcaflex license is required to work with the orcaflex API.
+
+    """
+
+    dirs = np.array(self.dir.values)
+    freqs = np.array(self.freq.values)
+
+    ddir = self.dd
+
+    nTrains = 0
+    env = model.environment  #alias
+
+    for dir in dirs:
+        e = self.efth.sel(dict(dir=dir))
+
+        E = ddir * e
+
+        if np.sum(E) <= minEnergy:
+            continue
+
+        nTrains+=1
+
+        env.NumberOfWaveTrains = nTrains
+        env.SelectedWaveTrainIndex = nTrains -1 # zero-based = f'Wave{nTrains}'
+        env.WaveDirection = np.mod(90-dir + 180, 360) # convert from coming from to going to and from compass to ofx
+        env.WaveType = 'User Defined Spectrum'
+        env.WaveNumberOfSpectralDirections = 1
+
+        # interior points in the spectrum with zero energy are not allowed by orcaflex
+        iFirst = np.where(E>0)[0][0]
+        iLast = np.where(E>0)[0][-1]
+
+        for i in range(iFirst, iLast):
+            if E[i]<1e-10:
+                E[i] = 1e-10
+
+        if iFirst > 0:
+            iFirst -=1
+        if iLast < len(E)-2:
+            iLast += 1
+
+        env.WaveNumberOfUserSpectralPoints = len(E[iFirst:iLast])
+        env.WaveSpectrumS = E[iFirst:iLast]
+        env.WaveSpectrumFrequency = freqs[iFirst:iLast]  # convert o rad/s
+
+    if nTrains == 0:
+        raise ValueError("No data exported, no directions with more than the minimum amount of energy")
+
+
+

--- a/wavespectra/output/orcaflex.py
+++ b/wavespectra/output/orcaflex.py
@@ -88,7 +88,18 @@ def to_orcaflex(self, model, minEnergy=1e-6):
 
         env.WaveNumberOfUserSpectralPoints = len(E[iFirst:iLast])
         env.WaveSpectrumS = E[iFirst:iLast]
-        env.WaveSpectrumFrequency = freqs[iFirst:iLast]  # convert o rad/s
+        env.WaveSpectrumFrequency = freqs[iFirst:iLast]
+
+        env.WaveType = 'Airy'  #Temporary set the wave-type to Airy. This is to avoid re-calcultion of
+                               # the spectral properties each time the next train is set (can slow-down
+                               # considerably when using many sprectral components
+                               # !thank you people at orcina for your help solving this!
+
+
+    # When all data is set, restore all trains to 'user-defined'. The data that we set earlier
+    # will still be there.
+    for env.SelectedWaveTrainIndex in range(nTrains):
+        env.WaveType = 'User Defined Spectrum'
 
     if nTrains == 0:
         raise ValueError(


### PR DESCRIPTION
Adds a function to export a single spectrum to the [orcaflex](https://www.orcina.com/orcaflex/) time-domain simulation program.

Note that an orcaflex license is required to do this.
The tests will try to run this test but will not fail if the orcaflex API can not be loaded.

Running the tests on a machine with orcaflex license gives the following output:

Time-domain signal from orcaflex simultation:
![image](https://user-images.githubusercontent.com/34062862/114504950-38e21200-9c62-11eb-92f3-56463995e166.png)

Comparison oned() input spectrum and spectrum re-calculated from time-domain signal using welch() 👍 
![image](https://user-images.githubusercontent.com/34062862/114505024-57480d80-9c62-11eb-8eb4-cbc19206b38f.png)

Screenshot of orcaflex model with exported spectrum:
![image](https://user-images.githubusercontent.com/34062862/114505064-65962980-9c62-11eb-85ac-00ce94605c73.png)

