### PR TITLE
Fixed test_zarr

### DIFF
--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -98,11 +98,14 @@ class TestIO(object):
     def test_zarr(self):
         """Check reading of zarr dataset in ww3 format."""
         filename = os.path.join(FILES_DIR, "ww3file.zarr")
+
         dset = read_ww3(filename, file_format="zarr")
         outfile = os.path.join(self.tmp_dir, "tmp.nc")
+        print(outfile)
         dset.spec.to_netcdf(outfile)
+
         dset2 = read_netcdf(outfile)
-        dset.equals(dset2)
+        xr.testing.assert_allclose(dset, dset2, atol=5e-6)
 
     def _read(self):
         self.infile = os.path.join(FILES_DIR, self.filename)

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -98,12 +98,9 @@ class TestIO(object):
     def test_zarr(self):
         """Check reading of zarr dataset in ww3 format."""
         filename = os.path.join(FILES_DIR, "ww3file.zarr")
-
         dset = read_ww3(filename, file_format="zarr")
         outfile = os.path.join(self.tmp_dir, "tmp.nc")
-        print(outfile)
         dset.spec.to_netcdf(outfile)
-
         dset2 = read_netcdf(outfile)
         xr.testing.assert_allclose(dset, dset2, atol=5e-6)
 


### PR DESCRIPTION
test_zarr did not do any tests.

Added a comparison with atol=5e-6. This tolerance is needed because there is a small difference in the efth data.

On windows the teardown function fails because the .nc file can not be deleted because it is still open.