### PR TITLE
Fixsel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - 3.9
   - 3.8
   - 3.7
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -24,7 +24,7 @@ Bug Fixes
 
 Internal Changes
 ----------------
-* Only interpolate with inverse distance weighting if 2 or more neighbour sites are found within tolerance (`PR60 <https://github.com/wavespectra/wavespectra/pull/60>`_).
+* Only interpolate with inverse distance weighting if 2 or more neighbour sites are found within tolerance (`PR62 <https://github.com/wavespectra/wavespectra/pull/62>`_).
 
 
 3.10.0 (2021-08-21)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -22,6 +22,10 @@ Bug Fixes
 ---------
 * Fix bug in direction calculation caused by changes in xr ufuncs (`PR59 <https://github.com/wavespectra/wavespectra/pull/59>`_).
 
+Internal Changes
+----------------
+* Only interpolate with inverse distance weighting if 2 or more neighbour sites are found within tolerance (`PR60 <https://github.com/wavespectra/wavespectra/pull/60>`_).
+
 
 3.10.0 (2021-08-21)
 __________________

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,9 +10,10 @@ wavespectra
 Python library for wave spectra
 -------------------------------
 
-Wavespectra is an open source project for working with ocean wave spectral data.
-The library is built on top of `xarray`_, leveraging from xarray's labelled
-multi-dimensional arrays and making dealing with wave spectra simple and fast.
+Wavespectra is an open source project for working with ocean wave spectral data hosted
+on https://github.com/wavespectra/wavespectra. The library is built on top of
+`xarray`_, leveraging from xarray's labelled multi-dimensional arrays and making
+dealing with wave spectra simple and fast.
 
 .. _xarray: https://xarray.pydata.org/en/stable/
 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Physics",
     "Topic :: Scientific/Engineering :: Visualization",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = py37, py38
+envlist = py37, py38 py39
 
 [travis]
 python =
+    3.9: py39
     3.8: py38
     3.7: py37
 

--- a/wavespectra/core/select.py
+++ b/wavespectra/core/select.py
@@ -238,7 +238,7 @@ def sel_idw(
                 break
             factors.append(1.0 / dist)
         # Mask it if no neighbour is found
-        if len(indices) == 0:
+        if len(indices) < 2:
             dsout.append(mask)
         else:
             # Inverse distance weighting

--- a/wavespectra/specdataset.py
+++ b/wavespectra/specdataset.py
@@ -116,32 +116,32 @@ class SpecDataset(metaclass=Plugin):
         """Select stations near or at locations defined by (lons, lats) vector.
 
         Args:
-            lons (list): Longitude values of locations to select.
-            lats (list): Latitude values of locations to select.
-            method (str): Method to use for inexact matches:
-            * idw: Inverse distance weighting selection.
-            * nearest: Nearest site selection.
-            * bbox: Sites inside bbox [min(lons), min(lats)], [max(lons), max(lats)].
-            * None: Only exact matches.
-            tolerance (float): Maximum distance between locations and original stations
-                for inexact matches.
-            dset_lons (array): Longitude of stations in dset, not required but could
-                help improove speed.
-            dset_lats (array): Latitude of stations in dset, not required but could
-                help improove speed.
-            kwargs: Extra keywargs to pass to the respective sel function
-                (i.e., `sel_nearest`, `sel_idw`).
+            - lons (list): Longitude values of locations to select.
+            - lats (list): Latitude values of locations to select.
+            - method (str): Method to use for inexact matches:
+                * idw: Inverse distance weighting selection.
+                * nearest: Nearest site selection.
+                * bbox: Sites inside bbox [min(lons), min(lats)], [max(lons), max(lats)].
+                * None: Only exact matches.
+            - tolerance (float): Maximum distance between locations and original stations
+              for inexact matches.
+            - dset_lons (array): Longitude of stations in dset, not required but could
+              help improove speed.
+            - dset_lats (array): Latitude of stations in dset, not required but could
+              help improove speed.
+            - kwargs: Extra keywargs to pass to the respective sel function
+              (i.e., `sel_nearest`, `sel_idw`).
 
         Return:
-            Stations Dataset selected at locations defined by zip(lons, lats).
+            - dset (SpecDataset): Stations Dataset selected at locations defined by zip(lons, lats).
 
         Note:
-            `tolerance` behaves differently with methods 'idw' and 'nearest'. In 'idw'
-                sites with no neighbours within `tolerance` are masked whereas in
-                'nearest' an exception is raised.
-            `dset_lons`, `dset_lats` are not required but can improve performance when
-                `dset` is chunked with site=1 (expensive to access site coords) and
-                improve precision if projected coors are provided at high latitudes.
+            - `tolerance` behaves differently with methods 'idw' and 'nearest'. In 'idw'
+              sites with no neighbours within `tolerance` are masked whereas in
+              'nearest' an exception is raised.
+            - `dset_lons`, `dset_lats` are not required but can improve performance when
+              `dset` is chunked with site=1 (expensive to access site coords) and
+              improve precision if projected coors are provided at high latitudes.
 
         """
         funcs = {


### PR DESCRIPTION
Inverse distance weighting method in `sel` produces garbage if only one neighbouring site is found within tolerance. Here we make sure sites are masked at these locations.