### PR TITLE
Rtd

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,11 @@
+version: 2
+
+formats:
+  - pdf
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+  apt_packages:
+    - gfortran

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,4 +19,4 @@ build:
     - gfortran
 
 sphinx:
-  fail_on_warning: true
+  fail_on_warning: false

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,6 +3,10 @@ version: 2
 formats:
   - pdf
 
+python:
+  install:
+    - requirements: requirements/requirements_doc.txt
+
 build:
   os: ubuntu-22.04
   tools:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,3 +13,6 @@ build:
     python: "3.10"
   apt_packages:
     - gfortran
+
+sphinx:
+  fail_on_warning: true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,10 @@ formats:
 
 python:
   install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - extra
     - requirements: requirements/requirements_doc.txt
 
 build:


### PR DESCRIPTION
Add readthedocs config to handle environment and stop relying on pure-python branch in order to build docs.