### PR TITLE
Octopus

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,11 +18,13 @@ ___________________
 
 New Features
 ------------
+* Support ERA5 and NDBC netcdf file types in `read_dataset` reader.
 * Support datasets with no lat / lon variables when writing octopus and swan ascii.
   There is now an option to specify the coordinates manually or skip specifying them.
 
 Internal Changes
 ----------------
+* Stop relying on lon/lat coordinates in order to identify file types in read_dataset.
 * Ensure octopus writer can handle lon/lat defined as coordinates in dataset rather
   than data_vars.
 * Fix octopus writer to support datasets without site as a dimension.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,6 +13,15 @@ Releases
 ********
 
 
+3.17.0 (2023-12-14)
+___________________
+
+New Features
+------------
+* Support datasets with no lat / lon variables when writing octopus and swan ascii.
+  There is now an option to specify the coordinates manually or skip specifying them.
+
+
 3.16.0 (2023-12-14)
 ___________________
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -26,7 +26,7 @@ Internal Changes
 * Ensure octopus writer can handle lon/lat defined as coordinates in dataset rather
   than data_vars.
 * Fix octopus writer to support datasets without site as a dimension.
-
+* Fix swan ascii writer for bug in cases where lon/lat are dimensions and site is not.
 
 3.16.0 (2023-12-14)
 ___________________

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -21,6 +21,12 @@ New Features
 * Support datasets with no lat / lon variables when writing octopus and swan ascii.
   There is now an option to specify the coordinates manually or skip specifying them.
 
+Internal Changes
+----------------
+* Ensure octopus writer can handle lon/lat defined as coordinates in dataset rather
+  than data_vars.
+* Fix octopus writer to support datasets without site as a dimension.
+
 
 3.16.0 (2023-12-14)
 ___________________

--- a/tests/io/test_octopus.py
+++ b/tests/io/test_octopus.py
@@ -45,6 +45,25 @@ class TestOctopus(object):
         ds = read_ncswan(self.ncswanfile).transpose("site", "time", ...)
         ds.spec.to_octopus(os.path.join(self.tmp_dir, "spectra.oct"))
 
+    def test_write_octopus_no_latlon_specify(self):
+        ds = read_ncswan(self.ncswanfile).drop(("lon", "lat"))
+        lons = [180.0]
+        lats = [-30.0]
+        filename = os.path.join(self.tmp_dir, "spectra.oct")
+        ds.spec.to_octopus(filename, lons=lons, lats=lats)
+        ds2 = read_octopus(filename)
+        assert sorted(ds2.lon.values) == sorted(lons)
+        assert sorted(ds2.lat.values) == sorted(lats)
+
+    def test_write_octopus_no_latlon_do_not_specify(self):
+        ds = read_ncswan(self.ncswanfile).drop(("lon", "lat"))
+        filename = os.path.join(self.tmp_dir, "spectra.oct")
+        ds.spec.to_octopus(filename)
+        ds2 = read_octopus(filename)
+        assert list(ds2.lon.values) == list(ds2.lon.values * 0)
+        assert list(ds2.lat.values) == list(ds2.lat.values * 0)
+        import ipdb; ipdb.set_trace()
+
     def test_write_octopus_and_read(self):
         ds = read_ncswan(self.ncswanfile)
         file = os.path.join(self.tmp_dir, "spectra.oct")

--- a/tests/io/test_octopus.py
+++ b/tests/io/test_octopus.py
@@ -62,7 +62,6 @@ class TestOctopus(object):
         ds2 = read_octopus(filename)
         assert list(ds2.lon.values) == list(ds2.lon.values * 0)
         assert list(ds2.lat.values) == list(ds2.lat.values * 0)
-        import ipdb; ipdb.set_trace()
 
     def test_write_octopus_and_read(self):
         ds = read_ncswan(self.ncswanfile)
@@ -75,12 +74,6 @@ class TestOctopus(object):
         ds = read_ncswan(self.ncswanfile)
         ds = ds.drop_vars([attrs.WSPDNAME, attrs.WDIRNAME, attrs.DEPNAME])
         ds.spec.to_octopus(os.path.join(self.tmp_dir, "spec_no_winds_depth.oct"))
-
-    def test_write_octopus_missing_lonlat(self):
-        ds = read_ncswan(self.ncswanfile)
-        ds = ds.rename({"lon": "x", "lat": "y"})
-        with pytest.raises(NotImplementedError):
-            ds.spec.to_octopus(os.path.join(self.tmp_dir, "spec_no_lonlat.oct"))
 
     def test_write_octopus_one_time(self):
         ds = read_ncswan(self.ncswanfile)

--- a/tests/io/test_octopus.py
+++ b/tests/io/test_octopus.py
@@ -33,6 +33,18 @@ class TestOctopus(object):
         ds = read_ncswan(self.ncswanfile)
         ds.spec.to_octopus(os.path.join(self.tmp_dir, "spectra.oct"))
 
+    def test_write_octopus_site_as_variable(self):
+        ds = read_ncswan(self.ncswanfile).isel(site=0)
+        ds.spec.to_octopus(os.path.join(self.tmp_dir, "spectra.oct"))
+
+    def test_write_octopus_lat_lon(self):
+        ds = read_ncswan(self.ncswanfile).isel(site=0).set_coords(("lon","lat"))
+        ds.spec.to_octopus(os.path.join(self.tmp_dir, "spectra.oct"))
+
+    def test_write_octopus_dims_ordering(self):
+        ds = read_ncswan(self.ncswanfile).transpose("site", "time", ...)
+        ds.spec.to_octopus(os.path.join(self.tmp_dir, "spectra.oct"))
+
     def test_write_octopus_and_read(self):
         ds = read_ncswan(self.ncswanfile)
         file = os.path.join(self.tmp_dir, "spectra.oct")

--- a/tests/io/test_octopus.py
+++ b/tests/io/test_octopus.py
@@ -37,7 +37,7 @@ class TestOctopus(object):
         ds = read_ncswan(self.ncswanfile).isel(site=0)
         ds.spec.to_octopus(os.path.join(self.tmp_dir, "spectra.oct"))
 
-    def test_write_octopus_lat_lon(self):
+    def test_write_octopus_latlon_as_dims(self):
         ds = read_ncswan(self.ncswanfile).isel(site=0).set_coords(("lon","lat"))
         ds.spec.to_octopus(os.path.join(self.tmp_dir, "spectra.oct"))
 

--- a/tests/io/test_octopus.py
+++ b/tests/io/test_octopus.py
@@ -46,7 +46,7 @@ class TestOctopus(object):
         ds.spec.to_octopus(os.path.join(self.tmp_dir, "spectra.oct"))
 
     def test_write_octopus_no_latlon_specify(self):
-        ds = read_ncswan(self.ncswanfile).drop(("lon", "lat"))
+        ds = read_ncswan(self.ncswanfile).drop_vars(("lon", "lat"))
         lons = [180.0]
         lats = [-30.0]
         filename = os.path.join(self.tmp_dir, "spectra.oct")
@@ -56,7 +56,7 @@ class TestOctopus(object):
         assert sorted(ds2.lat.values) == sorted(lats)
 
     def test_write_octopus_no_latlon_do_not_specify(self):
-        ds = read_ncswan(self.ncswanfile).drop(("lon", "lat"))
+        ds = read_ncswan(self.ncswanfile).drop_vars(("lon", "lat"))
         filename = os.path.join(self.tmp_dir, "spectra.oct")
         ds.spec.to_octopus(filename)
         ds2 = read_octopus(filename)

--- a/tests/io/test_swan_ascii.py
+++ b/tests/io/test_swan_ascii.py
@@ -12,7 +12,7 @@ FILES_DIR = Path(__file__).parent / "../sample_files"
 
 
 
-class TestNcSwan(object):
+class TestSwan(object):
     """Test read swan ascii functions."""
 
     @classmethod
@@ -54,3 +54,21 @@ class TestNcSwan(object):
             assert self.ds.isel(site=0).spec.hs().values == pytest.approx(
                 ds.isel(lon=0, lat=0, drop=True).spec.hs().values, rel=1e-2
             )
+
+    def test_write_swanascii_no_latlon_specify(self):
+        ds = self.ds.drop_vars(("lon", "lat"))
+        lons = [180.0]
+        lats = [-30.0]
+        filename = os.path.join(self.tmp_dir, "spectra.swn")
+        ds.spec.to_swan(filename, lons=lons, lats=lats)
+        ds2 = read_swan(filename)
+        assert sorted(ds2.lon.values) == sorted(lons)
+        assert sorted(ds2.lat.values) == sorted(lats)
+
+    def test_write_swanascii_no_latlon_do_not_specify(self):
+        ds = self.ds.drop_vars(("lon", "lat"))
+        filename = os.path.join(self.tmp_dir, "spectra.swn")
+        ds.spec.to_swan(filename)
+        ds2 = read_swan(filename)
+        assert list(ds2.lon.values) == list(ds2.lon.values * 0)
+        assert list(ds2.lat.values) == list(ds2.lat.values * 0)

--- a/tests/io/test_swan_ascii.py
+++ b/tests/io/test_swan_ascii.py
@@ -72,3 +72,8 @@ class TestSwan(object):
         ds2 = read_swan(filename)
         assert list(ds2.lon.values) == list(ds2.lon.values * 0)
         assert list(ds2.lat.values) == list(ds2.lat.values * 0)
+
+    def test_write_swanascii_latlon_as_dims_and_no_site_dim(self):
+        ds = self.ds.isel(site=0).set_coords(("lon","lat"))
+        filename = os.path.join(self.tmp_dir, "spectra.swn")
+        ds.spec.to_swan(filename)

--- a/wavespectra/__init__.py
+++ b/wavespectra/__init__.py
@@ -13,7 +13,7 @@ except ImportError:
     warnings.warn("Cannot import accessors at the main module level")
 
 
-__version__ = "3.16.0"
+__version__ = "3.17.0"
 
 
 def _import_read_functions(pkgname="input"):

--- a/wavespectra/input/dataset.py
+++ b/wavespectra/input/dataset.py
@@ -4,6 +4,8 @@ import logging
 from wavespectra.input.ww3 import from_ww3
 from wavespectra.input.wwm import from_wwm
 from wavespectra.input.ncswan import from_ncswan
+from wavespectra.input.era5 import from_era5
+from wavespectra.input.ndbc import from_ndbc
 from wavespectra.specdataset import SpecDataset
 
 logger = logging.getLogger(__name__)
@@ -20,17 +22,12 @@ def read_dataset(dset):
             consistent any supported file format (currently WW3, SWAN and WWM).
 
     """
-    vars_wavespectra = {"freq", "dir", "site", "efth", "lon", "lat"}
-    vars_ww3 = {"frequency", "direction", "station", "efth", "longitude", "latitude"}
-    vars_wwm = {"nfreq", "ndir", "nbstation", "AC", "lon", "lat"}
-    vars_ncswan = {
-        "frequency",
-        "direction",
-        "points",
-        "density",
-        "longitude",
-        "latitude",
-    }
+    vars_wavespectra = {"freq", "dir", "site", "efth"}
+    vars_ww3 = {"frequency", "direction", "station", "efth"}
+    vars_wwm = {"nfreq", "ndir", "nbstation", "AC"}
+    vars_era5 = {"frequency", "direction", "d2fd"}
+    vars_ndbc = {"frequency", "direction", "spectral_wave_density"}
+    vars_ncswan = {"frequency", "direction", "points", "density"}
 
     vars_dset = set(dset.variables.keys()).union(dset.dims)
     if not vars_wavespectra - vars_dset:
@@ -45,6 +42,12 @@ def read_dataset(dset):
     elif not vars_wwm - vars_dset:
         logger.debug("Dataset identified as wwm")
         func = from_wwm
+    elif not vars_era5 - vars_dset:
+        logger.debug("Dataset identified as era5")
+        func = from_era5
+    elif not vars_ndbc - vars_dset:
+        logger.debug("Dataset identified as ndbc")
+        func = from_ndbc
     else:
         raise ValueError(
             f"Cannot identify appropriate reader from dataset variables: {vars_dset}"

--- a/wavespectra/input/ncswan.py
+++ b/wavespectra/input/ncswan.py
@@ -53,11 +53,11 @@ def read_ncswan(filename_or_fileglob, file_format="netcdf", mapping=MAPPING, chu
 def from_ncswan(dset):
     """Format SWAN netcdf dataset to receive wavespectra accessor.
 
-    Args:o
-        dset (xr.Dataset): Dataset created from a SWAN netcdf file.
+    Args:
+        - dset (xr.Dataset): Dataset created from a SWAN netcdf file.
 
     Returns:
-        Formated dataset with the SpecDataset accessor in the `spec` namespace.
+        - Formated dataset with the SpecDataset accessor in the `spec` namespace.
 
     """
     dset = dset.rename(MAPPING)

--- a/wavespectra/input/ndbc.py
+++ b/wavespectra/input/ndbc.py
@@ -3,7 +3,6 @@
 https://dods.ndbc.noaa.gov/
 
 """
-import warnings
 import xarray as xr
 import numpy as np
 

--- a/wavespectra/output/octopus.py
+++ b/wavespectra/output/octopus.py
@@ -116,8 +116,8 @@ def to_octopus(
         ).transpose(attrs.TIMENAME, attrs.SITENAME, attrs.DIRNAME, attrs.FREQNAME).values
 
         try:
-            lons = dset_dict["lon"]
-            lats = dset_dict["lat"]
+            lons = np.atleast_1d(dset_dict["lon"])
+            lats = np.atleast_1d(dset_dict["lat"])
         except KeyError as err:
             raise NotImplementedError(
                 "lon-lat variables are required to write Octopus spectra file"

--- a/wavespectra/output/swan.py
+++ b/wavespectra/output/swan.py
@@ -1,4 +1,5 @@
 """SWAN ASCII output plugin."""
+import numpy as np
 from wavespectra.core.attributes import attrs
 from wavespectra.core.swan import SwanSpecFile
 
@@ -8,7 +9,9 @@ def to_swan(
     filename,
     append=False,
     id="Created by wavespectra",
-    ntime=None
+    ntime=None,
+    lons=None,
+    lats=None,
 ):
     """Write spectra in SWAN ASCII format.
 
@@ -18,9 +21,14 @@ def to_swan(
         - id (str): used for header in output file.
         - ntime (int, None): number of times to load into memory before dumping output
           file if full dataset does not fit into memory, choose None to load all times.
+        - lons: (np.array, None): longitudes to use for each site, if None use.
+        - lats: (np.array, None): latitudes to use for each site, if None use.
 
     Note:
-        - Only datasets with lat/lon coordinates are currently supported.
+        - lons/lats parameters may be prescribed to set site locations if lon/lat are
+          not variables in the dataset (their sizes must match the number of sites).
+        - If lons/lats are not specified and the dataset does not have lon/lat coords,
+          all coordinates default to zero.
         - Extra dimensions other than time, site, lon, lat, freq, dim not yet
           supported.
         - Only 2D spectra E(f,d) are currently supported.
@@ -32,6 +40,15 @@ def to_swan(
     # If grid reshape into site, otherwise ensure there is site dim to iterate over
     dset = self._check_and_stack_dims()
     ntime = min(ntime or dset.time.size, dset.time.size)
+
+    # Handle datasets with missing lon/lat
+    for arr, name in zip((lons, lats), (attrs.LONNAME, attrs.LATNAME)):
+        if name not in dset.data_vars:
+            if arr is None:
+                arr = np.zeros(dset.site.size)
+            elif len(arr) != dset.site.size:
+                raise ValueError(f"{name} must have same size as site dimension")
+            dset[name] = (("site",), arr)
 
     # Ensure time dimension exists
     is_time = attrs.TIMENAME in dset[attrs.SPECNAME].dims
@@ -50,20 +67,13 @@ def to_swan(
     dset = dset.transpose(attrs.TIMENAME, attrs.SITENAME, attrs.FREQNAME, attrs.DIRNAME)
 
     # Instantiate swan object
-    try:
-        x = dset.lon.values
-        y = dset.lat.values
-    except AttributeError as err:
-        raise NotImplementedError(
-            "lon-lat variables are required to write SWAN spectra file"
-        ) from err
     sfile = SwanSpecFile(
         filename,
         freqs=dset.freq,
         dirs=dset.dir,
         time=is_time,
-        x=x,
-        y=y,
+        x=dset[attrs.LONNAME].values,
+        y=dset[attrs.LATNAME].values,
         append=append,
         id=id,
     )

--- a/wavespectra/specdataset.py
+++ b/wavespectra/specdataset.py
@@ -107,6 +107,11 @@ class SpecDataset(metaclass=Plugin):
         if attrs.LATNAME in dset.coords:
             dset = dset.reset_coords(attrs.LATNAME)
 
+        # Ensure site dim in lon/lat
+        for coord in [attrs.LONNAME, attrs.LATNAME]:
+            if coord in dset.data_vars and attrs.SITENAME not in dset[coord].dims:
+                dset[coord] = dset[coord].expand_dims(attrs.SITENAME)
+
         # Ensure times comes first
         if attrs.TIMENAME in dset.dims:
             dset = dset.transpose(attrs.TIMENAME, attrs.SITENAME, ...)

--- a/wavespectra/specdataset.py
+++ b/wavespectra/specdataset.py
@@ -96,10 +96,20 @@ class SpecDataset(metaclass=Plugin):
             )
 
         # If grid reshape into site, if neither define fake site dimension
-        if set(("lon", "lat")).issubset(dset.dims):
-            dset = dset.stack(site=("lat", "lon"))
-        elif "site" not in dset.dims:
-            dset = dset.expand_dims("site")
+        if set((attrs.LONNAME, attrs.LATNAME)).issubset(dset.dims):
+            dset = dset.stack(site=(attrs.LATNAME, attrs.LONNAME))
+        elif attrs.SITENAME not in dset.dims:
+            dset = dset.expand_dims(attrs.SITENAME)
+
+        # Ensure lon/lat are not coordinates
+        if attrs.LONNAME in dset.coords:
+            dset = dset.reset_coords(attrs.LONNAME)
+        if attrs.LATNAME in dset.coords:
+            dset = dset.reset_coords(attrs.LATNAME)
+
+        # Ensure times comes first
+        if attrs.TIMENAME in dset.dims:
+            dset = dset.transpose(attrs.TIMENAME, attrs.SITENAME, ...)
 
         return dset
 

--- a/wavespectra/specdataset.py
+++ b/wavespectra/specdataset.py
@@ -97,7 +97,7 @@ class SpecDataset(metaclass=Plugin):
 
         # If grid reshape into site, if neither define fake site dimension
         if set((attrs.LONNAME, attrs.LATNAME)).issubset(dset.dims):
-            dset = dset.stack(site=(attrs.LATNAME, attrs.LONNAME))
+            dset = dset.stack(site=(attrs.LATNAME, attrs.LONNAME), create_index=False)
         elif attrs.SITENAME not in dset.dims:
             dset = dset.expand_dims(attrs.SITENAME)
 


### PR DESCRIPTION
Improvements to octopus and swan ascii writers:

* Support datasets in which site is not a dimension and/or are scalars
* Support datasets without lon/lat data_vars
* Avoid issues when lon/lat are coordinates instead of data_vars
* Allow manually specifying lon/lat if dataset does not have them, or ignoring them

Changes to read_dataset input funciton:

* Support era5 and ndbc netcdf file formats
* Stop relying on lon/lat coordinates in order to identify the appropriate file type