### PR TITLE
Ignore optional location names when reading SWAN spectra headers (fixes #84)

### DIFF
--- a/tests/io/test_swan_ascii.py
+++ b/tests/io/test_swan_ascii.py
@@ -59,6 +59,51 @@ def test_read_swan_multiple_locations(dset, tmpdir):
     assert ds1.equals(ds2)
 
 
+def test_read_swan_named_locations(dset, tmpdir):
+    """Locations may carry an optional name after the coordinates (#84).
+
+    SWAN allows the names of locations to be written behind the two coordinates
+    in the header; these are ignored by SWAN when reading the file. ``read_swan``
+    must skip such trailing names instead of trying to parse them as floats.
+    """
+    reference = tmpdir / "swanfile.spec"
+    named = tmpdir / "swanfile_named.spec"
+    ds = xr.concat([dset, dset, dset], dim="site")
+    ds["site"] = [1, 2, 3]
+    ds.spec.to_swan(reference)
+
+    # Append a location name to every coordinate line of the locations block.
+    lines = Path(reference).read_text().splitlines()
+    out = []
+    in_locs = False
+    nlocs = 0
+    for line in lines:
+        header = line.split()[0] if line.split() else ""
+        if header in ("LONLAT", "LOCATIONS"):
+            in_locs = True
+            nlocs = -1  # next line is the count
+            out.append(line)
+            continue
+        if in_locs and nlocs == -1:
+            nlocs = int(line.split()[0])
+            out.append(line)
+            continue
+        if in_locs and nlocs > 0:
+            out.append(line.rstrip() + f"    station_{nlocs}")
+            nlocs -= 1
+            if nlocs == 0:
+                in_locs = False
+            continue
+        out.append(line)
+    Path(named).write_text("\n".join(out) + "\n")
+
+    ds_ref = read_swan(reference, as_site=True)
+    ds_named = read_swan(named, as_site=True)
+    assert np.array_equal(ds_named.lon.values, ds_ref.lon.values)
+    assert np.array_equal(ds_named.lat.values, ds_ref.lat.values)
+    assert ds_ref.equals(ds_named)
+
+
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_read_swan_inconsistent_times(dset, tmpdir):
     """Test spectra is read without winds and depth if times are inconsistent."""

--- a/wavespectra/core/swan.py
+++ b/wavespectra/core/swan.py
@@ -69,9 +69,12 @@ class SwanSpecFile(object):
                 "LOCATIONS", True
             )
             for ip in locs:
-                xy = [float(val) for val in ip.split()]
-                self.x.append(xy[0])
-                self.y.append(xy[1])
+                # Only the first two tokens are the x/y coordinates. SWAN allows
+                # an optional location name to follow them in the header, which
+                # is ignored by SWAN when reading the file (see #84).
+                xy = ip.split()
+                self.x.append(float(xy[0]))
+                self.y.append(float(xy[1]))
             self.x = np.array(self.x)
             self.y = np.array(self.y)
             self.afreq = self._read_header("AFREQ", True)


### PR DESCRIPTION
## Summary

Fixes #84.

`SwanSpecFile.__init__` reads each location line of the `LONLAT`/`LOCATIONS` header with:

```python
xy = [float(val) for val in ip.split()]
```

SWAN allows an optional **location name** to be written after the two coordinates in the header (see the [SWAN docs](https://swanmodel.sourceforge.io/online_doc/swanuse/node50.html)):

> *Note that if the file is used for input for SWAN (but not generated by SWAN) and the user so desires, the names of locations can be written behind the two coordinates; these names are ignored by SWAN when reading the file.*

When such a name is present, `float('station_name')` raises `ValueError` and the whole file fails to read. The fix parses only the first two tokens of each location line as the x/y coordinates, ignoring any trailing name — matching SWAN's own behaviour.

## Reproduction (on `main`)

A SWAN ASCII spectra file whose location line carries a name, e.g.:

```
LONLAT                                  locations in spherical coordinates
     1                                  number of locations
  174.672501  -38.173599    WaveBuoy_Alpha
```

```python
>>> from wavespectra import read_swan
>>> read_swan('named.spec')
ValueError: could not convert string to float: 'WaveBuoy_Alpha'
```

## Fix

```python
for ip in locs:
    # Only the first two tokens are the x/y coordinates. SWAN allows
    # an optional location name to follow them in the header, which
    # is ignored by SWAN when reading the file (see #84).
    xy = ip.split()
    self.x.append(float(xy[0]))
    self.y.append(float(xy[1]))
```

## Verification

- New regression test `tests/io/test_swan_ascii.py::test_read_swan_named_locations`: writes a multi-location spectra file, appends a name to every coordinate line, and asserts that `read_swan` recovers identical `lon`/`lat` coordinates and an identical dataset to the un-named file. It **fails on `main`** (`ValueError: could not convert string to float: 'station_3'`) and **passes with this change**.
- The existing `tests/io/test_swan_ascii.py` suite (9 tests) continues to pass; the coordinate values and `hs` of an un-named file are unchanged.

This implements the fix suggested in #84.