### PR TITLE
Add funwave writer for the WK_NEW_DATA2D wavemaker format

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,17 @@ changelog covers the release history since v3.0 when wavespectra was open-source
 Releases
 ********
 
+4.5.0 (unreleased)
+___________________
+
+New Features
+------------
+* New ``to_funwave_new`` writer to save spectra as individual wave components in the
+  format expected by the FUNWAVE-TVD ``WK_NEW_DATA2D`` wavemaker (`WaveCompFile`),
+  supporting optional phases, direction clipping, 1D spectra and zip archives for
+  multiple spectra.
+
+
 4.4.3 (2026-06-02)
 ___________________
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -21,6 +21,9 @@ New Features
   format expected by the FUNWAVE-TVD ``WK_NEW_DATA2D`` wavemaker (`WaveCompFile`),
   supporting optional phases, direction clipping, 1D spectra and zip archives for
   multiple spectra.
+* New ``read_funwave_new`` reader to reconstruct gridded spectra from FUNWAVE-TVD
+  ``WK_NEW_DATA2D`` wave component files, also available as the ``funwave_new``
+  engine in ``xr.open_dataset``.
 
 
 4.4.3 (2026-06-02)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -144,6 +144,7 @@ Input functions
    read_ndbc_ascii
    read_json
    read_funwave
+   read_funwave_new
    read_xwaves
    read_dataset
    read_wavespectra

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -107,6 +107,7 @@ Output methods described in the `Output functions`_ section:
 :py:attr:`~SpecDataset.to_ww3`
 :py:attr:`~SpecDataset.to_json`
 :py:attr:`~SpecDataset.to_funwave`
+:py:attr:`~SpecDataset.to_funwave_new`
 :py:attr:`~SpecDataset.to_orcaflex`
 
 
@@ -174,6 +175,7 @@ Output functions
    SpecDataset.to_ww3
    SpecDataset.to_json
    SpecDataset.to_funwave
+   SpecDataset.to_funwave_new
    SpecDataset.to_orcaflex
 
 

--- a/docs/io-input.rst
+++ b/docs/io-input.rst
@@ -70,6 +70,7 @@ These input functions are currently available from the main module level:
     read_datawell
     read_era5
     read_funwave
+    read_funwave_new
     read_json
     read_ncswan
     read_ndbc

--- a/docs/io-output.rst
+++ b/docs/io-output.rst
@@ -38,6 +38,7 @@ These output functions are currently available as methods of :py:class:`~wavespe
     :toctree: generated/
 
     SpecDataset.to_funwave
+    SpecDataset.to_funwave_new
     SpecDataset.to_json
     SpecDataset.to_netcdf
     SpecDataset.to_octopus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ wavespectra = "wavespectra.cli:main"
 [project.entry-points."xarray.backends"]
 era5 = "wavespectra.input.era5:ERA5BackendEntrypoint"
 funwave = "wavespectra.input.funwave:FunwaveBackendEntrypoint"
+funwave_new = "wavespectra.input.funwave_new:FunwaveNewBackendEntrypoint"
 json = "wavespectra.input.json:JsonBackendEntrypoint"
 ncswan = "wavespectra.input.ncswan:NCSwanBackendEntrypoint"
 ndbc = "wavespectra.input.ndbc:NDBCBackendEntrypoint"

--- a/tests/io/test_funwave.py
+++ b/tests/io/test_funwave.py
@@ -6,7 +6,7 @@ import numpy as np
 import xarray as xr
 from zipfile import ZipFile
 
-from wavespectra import read_funwave, read_ww3
+from wavespectra import read_funwave, read_funwave_new, read_ww3
 
 
 FILES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../sample_files")
@@ -20,6 +20,7 @@ class TestFunwave:
         """Setup class."""
         self.tmp_dir = mkdtemp()
         self.filename = os.path.join(FILES_DIR, "funwavefile.txt")
+        self.filename_new = os.path.join(FILES_DIR, "funwave_new_file.txt")
         self.dsww3 = read_ww3(os.path.join(FILES_DIR, "ww3file.nc"))
 
     @classmethod
@@ -142,6 +143,52 @@ class TestFunwave:
         assert os.path.isfile(zipname)
         assert self._files_in_zip(zipname) == np.prod(
             self.dsww3.efth.isel(freq=0, dir=0).shape
+        )
+
+    def test_new_data2d_read_official_example(self):
+        """Read the two-wave example file from the Funwave repository.
+
+        Two components with amplitude 0.3 m and directions +-12 deg cartesian,
+        from simple_cases/wave_coherence/Case_DATA2D_2Waves.
+
+        """
+        dset = read_funwave_new(self.filename_new)
+        assert dset.freq.size == 1
+        assert sorted(dset.dir.values) == [258.0, 282.0]
+        assert float(dset.tp) == 8.0
+        hs = 4 * np.sqrt(2 * 0.3**2 / 2)
+        assert float(dset.spec.hs(tail=False)) == pytest.approx(hs, rel=1e-6)
+
+    def test_new_data2d_read(self):
+        """
+        * Write single wave component file from ww3 file.
+        * Read it back and compare stats from original and new datasets.
+        """
+        filename = os.path.join(self.tmp_dir, "fw_new_roundtrip.txt")
+        dset0 = self.dsww3.isel(time=0, site=0, drop=True)
+        dset0.spec.to_funwave_new(filename, clip=False)
+        dset1 = read_funwave_new(filename)
+        xr.testing.assert_allclose(
+            dset0.spec.stats(["hs", "tp", "dpm"]),
+            dset1.spec.stats(["hs", "tp", "dpm"]),
+            rtol=1e-3,
+        )
+
+    def test_new_data2d_read_1d(self):
+        """
+        * Write oned wave component file from ww3 file.
+        * Read it back and check stats and dimension consistency.
+        """
+        filename = os.path.join(self.tmp_dir, "fw_new_roundtrip_1d.txt")
+        dset0 = self.dsww3.isel(time=0, site=0, drop=True).spec.oned().to_dataset()
+        dset0.spec.to_funwave_new(filename, clip=False)
+        dset1 = read_funwave_new(filename)
+        assert dset1.spec.dd == 1
+        assert dset1.spec.dir is None
+        xr.testing.assert_allclose(
+            dset0.spec.stats(["hs", "tp"]),
+            dset1.spec.stats(["hs", "tp"]),
+            rtol=1e-3,
         )
 
     def test_new_data2d_1d(self):

--- a/tests/io/test_funwave.py
+++ b/tests/io/test_funwave.py
@@ -78,6 +78,83 @@ class TestFunwave:
         assert dir1.min() >= -90 and dir1.max() <= 90
         assert dir2.min() < -90 and dset2.dir.max() > 90
 
+    def _read_new_data2d(self, filename):
+        """Parse blocks from a WK_NEW_DATA2D wave component file."""
+        with open(filename) as fid:
+            lines = fid.readlines()
+        values = [float(line.split()[0]) for line in lines]
+        nc = int(values[0])
+        tp = values[1]
+        blocks = values[2:]
+        freq = np.array(blocks[:nc])
+        dire = np.array(blocks[nc : 2 * nc])
+        amp = np.array(blocks[2 * nc : 3 * nc])
+        phase = np.array(blocks[3 * nc : 4 * nc])
+        return nc, tp, freq, dire, amp, phase
+
+    def test_new_data2d_write_single(self):
+        """
+        * Write single wave component file from ww3 file.
+        * Check file structure and stats against the original dataset.
+        """
+        filename = os.path.join(self.tmp_dir, "fw_new.txt")
+        dset0 = self.dsww3.isel(time=0, site=0, drop=True)
+        dset0.spec.to_funwave_new(filename, clip=False)
+        nc, tp, freq, dire, amp, phase = self._read_new_data2d(filename)
+
+        assert nc == dset0.freq.size * dset0.dir.size
+        assert len(freq) == len(dire) == len(amp) == len(phase) == nc
+        assert tp == pytest.approx(float(dset0.spec.tp()), rel=1e-3)
+
+        # Sum of component energies a^2 / 2 recovers m0
+        hs = 4 * np.sqrt(np.sum(amp**2 / 2))
+        assert hs == pytest.approx(float(dset0.spec.hs(tail=False)), rel=1e-4)
+
+        # Directions in cartesian convention
+        dir0 = np.sort(np.unique(dire))
+        dir1 = (270 - dset0.dir.values) % 360
+        dir1[dir1 > 180] = dir1[dir1 > 180] - 360
+        assert np.allclose(dir0, np.sort(dir1))
+
+    def test_new_data2d_clip(self):
+        """Test directions outside [-90, 90] are clipped."""
+        filename = os.path.join(self.tmp_dir, "fw_new_clip.txt")
+        dset0 = self.dsww3.isel(time=0, site=0, drop=True)
+        dset0.spec.to_funwave_new(filename)
+        nc, tp, freq, dire, amp, phase = self._read_new_data2d(filename)
+        assert dire.min() >= -90 and dire.max() <= 90
+
+    def test_new_data2d_no_phases(self):
+        """Test the phase block is omitted with phases=False."""
+        filename = os.path.join(self.tmp_dir, "fw_new_nophase.txt")
+        dset0 = self.dsww3.isel(time=0, site=0, drop=True)
+        dset0.spec.to_funwave_new(filename, clip=False, phases=False)
+        nc, tp, freq, dire, amp, phase = self._read_new_data2d(filename)
+        assert phase.size == 0
+        with open(filename) as fid:
+            assert len(fid.readlines()) == 3 * nc + 2
+
+    def test_new_data2d_write_multi(self):
+        """Write multiple wave component files from ww3 dataset."""
+        filename = os.path.join(self.tmp_dir, "fw_new.txt")
+        zipname = filename.replace(".txt", ".zip")
+        self.dsww3.spec.to_funwave_new(filename)
+        assert os.path.isfile(zipname)
+        assert self._files_in_zip(zipname) == np.prod(
+            self.dsww3.efth.isel(freq=0, dir=0).shape
+        )
+
+    def test_new_data2d_1d(self):
+        """Write oned wave component file with all directions set to zero."""
+        filename = os.path.join(self.tmp_dir, "fw_new_1d.txt")
+        dset0 = self.dsww3.isel(time=0, site=0, drop=True).spec.oned().to_dataset()
+        dset0.spec.to_funwave_new(filename, clip=False)
+        nc, tp, freq, dire, amp, phase = self._read_new_data2d(filename)
+        assert nc == dset0.freq.size
+        assert np.all(dire == 0)
+        hs = 4 * np.sqrt(np.sum(amp**2 / 2))
+        assert hs == pytest.approx(float(dset0.spec.hs(tail=False)), rel=1e-4)
+
     def test_1d(self):
         """
         * Write oned funwave spectrum from ww3 file.

--- a/tests/sample_files/funwave_new_file.txt
+++ b/tests/sample_files/funwave_new_file.txt
@@ -1,0 +1,10 @@
+  2        - NumFreq
+  8.0      - PeakPeriod  
+  0.125    - Freq
+  0.125    - Freq
+ 12.000    - Dire
+-12.000    - Dire
+  0.3	   - Amp
+  0.3	   - Amp
+  0.0	   - Phase
+ 20.0      - Phase

--- a/wavespectra/__init__.py
+++ b/wavespectra/__init__.py
@@ -14,7 +14,7 @@ except ImportError:
     warnings.warn("Cannot import accessors at the main module level")
 
 
-__version__ = "4.4.3"
+__version__ = "4.5.0"
 
 
 def _import_functions(pkgname="input", prefix="read"):

--- a/wavespectra/input/funwave_new.py
+++ b/wavespectra/input/funwave_new.py
@@ -1,0 +1,104 @@
+"""Read Funwave WK_NEW_DATA2D Wave Maker files"""
+
+from xarray.backends import BackendEntrypoint
+import numpy as np
+import xarray as xr
+
+from wavespectra import SpecArray
+from wavespectra.input import read_ascii_or_binary
+from wavespectra.core.attributes import attrs, set_spec_attributes
+
+
+def read_funwave_new(filename_or_obj):
+    """Read Spectra in Funwave WK_NEW_DATA2D wavemaker format.
+
+    Args:
+        - filename_or_obj (str, filelike): Funwave WaveCompFile to read.
+
+    Returns:
+        - dset (SpecDataset): spectra dataset object read from funwave file.
+
+    Note:
+        - Format description: https://fengyanshi.github.io/build/html/wavemaker_coherence.html.
+        - The file describes individual wave components, the gridded spectrum is
+          reconstructed by summing component energies :math:`a^2/2` falling in each
+          frequency-direction bin defined by the unique frequencies and directions.
+        - Directions converted from Cartesian (0E, CCW, to) to wavespectra (0N, CW, from).
+        - A 1D :math:`E(f)` spectrum is returned if all directions are equal.
+        - Phases are ignored if present.
+
+    """
+    data = read_ascii_or_binary(filename_or_obj, mode="r")
+
+    # Remove any empty rows
+    data = [row for row in data if row != "\n"]
+
+    # Number of wave components
+    nc = int(data.pop(0).split()[0])
+
+    # Tp
+    tp = float(data.pop(0).split()[0])
+
+    # Wave component blocks
+    values = [float(row.split()[0]) for row in data]
+    freq = np.array(values[:nc])
+    dir = np.array(values[nc : 2 * nc])
+    amp = np.array(values[2 * nc : 3 * nc])
+
+    # Bin component energies onto the spectral grid
+    freqs = np.unique(freq)
+    dirs = np.unique(dir)
+    ifreq = np.searchsorted(freqs, freq)
+    idir = np.searchsorted(dirs, dir)
+    energy = np.zeros((freqs.size, dirs.size))
+    np.add.at(energy, (ifreq, idir), amp**2 / 2)
+
+    if dirs.size == 1:
+        coords = {attrs.FREQNAME: freqs}
+        dims = (attrs.FREQNAME,)
+        energy = energy.squeeze(axis=1)
+    else:
+        # Convert dir from cartesian to wavespectra convention
+        dirs = (270 - dirs) % 360
+
+        # Turn zero dir into 360 for continuity
+        i0 = np.where(dirs == 0)[0]
+        if i0.size > 0:
+            dirs[i0] = 360.0
+
+        coords = {attrs.FREQNAME: freqs, attrs.DIRNAME: dirs}
+        dims = (attrs.FREQNAME, attrs.DIRNAME)
+    darr = xr.DataArray(data=energy, coords=coords, dims=dims)
+
+    # Energy density spectrum
+    darr = darr / (darr.spec.df * darr.spec.dd)
+
+    # Define output dataset
+    dset = darr.to_dataset(name=attrs.SPECNAME)
+    if dirs.size > 1:
+        dset = dset.sortby(attrs.DIRNAME)
+    dset["tp"] = tp
+    set_spec_attributes(dset)
+    return dset
+
+
+class FunwaveNewBackendEntrypoint(BackendEntrypoint):
+    """Funwave WK_NEW_DATA2D backend engine."""
+
+    def open_dataset(
+        self,
+        filename_or_obj,
+        *,
+        drop_variables=None,
+    ):
+        return read_funwave_new(filename_or_obj)
+
+    def guess_can_open(self, filename_or_obj):
+        return False
+
+    description = (
+        "Open Funwave WK_NEW_DATA2D ASCII wave component files as a wavespectra "
+        "dataset."
+    )
+
+    url = "https://github.com/wavespectra/wavespectra"

--- a/wavespectra/output/funwave.py
+++ b/wavespectra/output/funwave.py
@@ -33,6 +33,46 @@ def to_funwave(
           zip archive defined by replacing the extension of `filename` by ".zip".
 
     """
+    _write_funwave(self, filename, clip, funwave_spectrum)
+
+
+def to_funwave_new(
+    self,
+    filename,
+    clip=True,
+    phases=True,
+):
+    """Write spectra in Funwave WK_NEW_DATA2D wavemaker format.
+
+    Args:
+        - filename (str): Name for output Funwave file.
+        - clip (bool): Clip directions outside [-90, 90] range in cartesian convention.
+        - phases (bool): Write random phases for each wave component, if False the
+          phase block is omitted and Funwave generates random phases itself.
+
+    Note:
+        - Format description: https://fengyanshi.github.io/build/html/wavemaker_coherence.html.
+        - Unlike the gridded WK_DATA2D format written by `to_funwave`, this format
+          describes individual wave components, one per spectral bin.
+        - Directions converted from  wavespectra (0N, CW, from) to Cartesian (0E, CCW, to).
+        - Funwave only deals with directions in the [-90, 90] range in cartesian
+          convention (components outside it are discarded by the model), use
+          clip=True to clip spectra outside that range.
+        - Both 2D :math:`E(f,d)` and 1d :math:`E(f)` spectra are supported.
+        - If the SpecArray has more than one spectrum, multiple files are created in a
+          zip archive defined by replacing the extension of `filename` by ".zip".
+
+    """
+    _write_funwave(
+        self,
+        filename,
+        clip,
+        lambda darr, fname: funwave_new_spectrum(darr, fname, phases=phases),
+    )
+
+
+def _write_funwave(self, filename, clip, spectrum_writer):
+    """Write one or multiple spectra using the given single-spectrum writer."""
     darr = self.efth.copy(deep=True)
 
     # Convert directions to Cartesian, going-to convention
@@ -50,7 +90,7 @@ def to_funwave(
 
     if not stack_dims or dimsizes == {1}:
         # Single spectrum in object, write directly to txt file
-        funwave_spectrum(darr, filename)
+        spectrum_writer(darr, filename)
 
     else:
         # Multiple spectra in object, write each txt file in a zip archive
@@ -71,7 +111,7 @@ def to_funwave(
                 # Write spectrum to zip archive
                 fname = os.path.basename(fpath) + "-" + prefix + fext
                 logger.debug(f"Write {fname} to {zipname}")
-                spectrum = funwave_spectrum(darr, None).getvalue()
+                spectrum = spectrum_writer(darr, None).getvalue()
                 zstream.writestr(fname, spectrum)
 
 
@@ -113,6 +153,75 @@ def funwave_spectrum(darr, filename):
     else:
         np.savetxt(s, amp, fmt="%12.8f", delimiter="")
         np.savetxt(s, phi, fmt="%12.3f", delimiter="")
+
+    # Save to file
+    if filename is not None:
+        with open(filename, "w") as fid:
+            fid.write(s.getvalue())
+
+    return s
+
+
+def funwave_new_spectrum(darr, filename, phases=True):
+    """Funwave WK_NEW_DATA2D spectrum memory buffer.
+
+    Args:
+        darr (SpecArray): Spectrum to write (only `freq`, `dir` dims are allowed).
+        filename (str): Name of file to save spectrum to, choose `None` if you don't
+            want to save it to file but only return the memory buffer.
+        phases (bool): Write random phases for each wave component, if False the
+            phase block is omitted and Funwave generates random phases itself.
+
+    Returns:
+        StringIO memory buffer with spectrum object.
+
+    Note:
+        The file describes one wave component per spectral bin, with blocks of
+        frequency (Hz), direction (degrees, cartesian) and amplitude (m) values,
+        optionally followed by a block of phases (degrees):
+
+        .. code-block:: none
+
+            NumFreq
+            PeakPeriod
+            Freq(1..NumFreq)
+            Dire(1..NumFreq)
+            Amp(1..NumFreq)
+            Phase(1..NumFreq)
+
+    """
+    # Ensure direction dim exists for 1D spectrum and has value 0
+    if attrs.DIRNAME not in darr.dims:
+        darr = darr.expand_dims({attrs.DIRNAME: [0]}, axis=-1)
+    elif darr[attrs.DIRNAME].size == 1:
+        darr = darr.assign_coords({attrs.DIRNAME: [0]})
+
+    # Component amplitudes from spectral bins
+    amp = np.sqrt(darr * darr.spec.df * darr.spec.dd * 8) / 2
+    amp = amp.transpose(attrs.FREQNAME, attrs.DIRNAME)
+
+    # Unpack bins into individual wave components
+    freq, dire = np.meshgrid(
+        darr[attrs.FREQNAME].values, darr[attrs.DIRNAME].values, indexing="ij"
+    )
+    freq = freq.ravel()
+    dire = dire.ravel()
+    amp = amp.values.ravel()
+    nc = freq.size
+
+    # Peak wave period
+    tp = float(darr.spec.tp())
+
+    # Create spectrum in memory buffer
+    s = StringIO()
+    s.write(f"{nc:>5d}   - NumFreq\n")
+    s.write(f"{tp:>10.3f}   - PeakPeriod\n")
+    s.write(nc * "%10.5f   - Freq\n" % tuple(freq))
+    s.write(nc * "%10.3f   - Dire\n" % tuple(dire))
+    s.write(nc * "%12.8f   - Amp\n" % tuple(amp))
+    if phases:
+        phi = np.random.uniform(0, 360.0, nc)
+        s.write(nc * "%12.3f   - Phase\n" % tuple(phi))
 
     # Save to file
     if filename is not None:


### PR DESCRIPTION
## Summary

New `to_funwave_new` output method on the `spec` accessor to write spectra as individual wave components in the `WaveCompFile` format expected by the FUNWAVE-TVD `WK_NEW_DATA2D` wavemaker (Salatin et al. 2021). Unlike the gridded `WK_DATA2D` format written by the existing `to_funwave`, this format describes one wave component per spectral bin.

## Details

- The file layout (`NumFreq`, `PeakPeriod`, then blocks of frequencies, directions, amplitudes and an optional block of phases) was verified against the reader implementation in FUNWAVE-TVD [`src/wavemaker.F`](https://github.com/fengyanshi/FUNWAVE-TVD/blob/master/src/wavemaker.F) and the official examples in [`simple_cases/wave_coherence`](https://github.com/fengyanshi/FUNWAVE-TVD/tree/master/simple_cases/wave_coherence), in addition to the [manual section](https://fengyanshi.github.io/build/html/wavemaker_coherence.html#wk-new-data2d).
- Component amplitudes use the same convention as the existing writer (`a = sqrt(8 E df dd) / 2`), which FUNWAVE consumes identically in both the WK_DATA2D and WK_NEW_DATA2D wavemakers.
- `phases=False` omits the phase block so FUNWAVE generates random phases itself.
- Directions are converted to the cartesian going-to convention and clipped to [-90, 90] by default, matching the model behaviour which discards components outside that range.
- 1D spectra and multiple spectra (written into a zip archive) are supported, mirroring `to_funwave`; the single-file/zip dispatch and direction conversion are factored into a shared `_write_funwave` helper.

## Test plan

- [x] New tests cover file structure, energy round trip (component amplitudes recover `hs(tail=False)`), direction clipping, phase omission, multi-spectra zip output and 1D spectra
- [x] All funwave IO tests pass (10 passed)
- [x] `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)