### PR TITLE
Fix NaN amplitudes from negative energy in funwave writers

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,7 +12,17 @@ changelog covers the release history since v3.0 when wavespectra was open-source
 Releases
 ********
 
-4.5.0 (unreleased)
+4.5.1 (unreleased)
+___________________
+
+Bug Fixes
+---------
+* Clip energy to non-negative before the ``sqrt`` in the ``to_funwave`` and
+  ``to_funwave_new`` writers so that tiny negative energy left by interpolation or
+  rotation (float cancellation, ~1e-21) no longer produces ``NaN`` amplitudes.
+
+
+4.5.0 (2026-06-16)
 ___________________
 
 New Features

--- a/tests/io/test_funwave.py
+++ b/tests/io/test_funwave.py
@@ -202,6 +202,28 @@ class TestFunwave:
         hs = 4 * np.sqrt(np.sum(amp**2 / 2))
         assert hs == pytest.approx(float(dset0.spec.hs(tail=False)), rel=1e-4)
 
+    def test_negative_energy_no_nan(self):
+        """Tiny negative energy must not produce NaN amplitudes.
+
+        Interpolation / rotation of spectra can leave bins with tiny negative
+        energy (~1e-21) from float cancellation. As amplitudes are computed via
+        sqrt(efth ...), those must be clipped to avoid NaN in the output.
+        """
+        dset0 = self.dsww3.isel(time=0, site=0, drop=True).copy(deep=True)
+        dset0["efth"][0, 0] = -1.0e-21
+
+        # Gridded format
+        filename = os.path.join(self.tmp_dir, "fw_neg.txt")
+        dset0.spec.to_funwave(filename, clip=False)
+        with open(filename) as fid:
+            assert "nan" not in fid.read().lower()
+
+        # Wave component (WK_NEW_DATA2D) format
+        filename_new = os.path.join(self.tmp_dir, "fw_new_neg.txt")
+        dset0.spec.to_funwave_new(filename_new, clip=False)
+        _, _, _, _, amp, _ = self._read_new_data2d(filename_new)
+        assert not np.isnan(amp).any()
+
     def test_1d(self):
         """
         * Write oned funwave spectrum from ww3 file.

--- a/wavespectra/__init__.py
+++ b/wavespectra/__init__.py
@@ -14,7 +14,7 @@ except ImportError:
     warnings.warn("Cannot import accessors at the main module level")
 
 
-__version__ = "4.5.0"
+__version__ = "4.5.1"
 
 
 def _import_functions(pkgname="input", prefix="read"):

--- a/wavespectra/output/funwave.py
+++ b/wavespectra/output/funwave.py
@@ -134,7 +134,9 @@ def funwave_spectrum(darr, filename):
         darr = darr.assign_coords({attrs.DIRNAME: [0]})
 
     # Amplitudes and phases
-    amp = np.sqrt(darr * darr.spec.df * darr.spec.dd * 8) / 2
+    # Clip to >=0 before sqrt: interpolation/rotation can leave tiny negative
+    # energy (~1e-21) from float cancellation, which would yield NaN amplitudes.
+    amp = np.sqrt(np.maximum(darr * darr.spec.df * darr.spec.dd * 8, 0.0)) / 2
     amp = amp.transpose()
     nd, nf = amp.shape
     phi = np.random.uniform(0, 1, (nd, nf)) * 360.0
@@ -197,7 +199,9 @@ def funwave_new_spectrum(darr, filename, phases=True):
         darr = darr.assign_coords({attrs.DIRNAME: [0]})
 
     # Component amplitudes from spectral bins
-    amp = np.sqrt(darr * darr.spec.df * darr.spec.dd * 8) / 2
+    # Clip to >=0 before sqrt: interpolation/rotation can leave tiny negative
+    # energy (~1e-21) from float cancellation, which would yield NaN amplitudes.
+    amp = np.sqrt(np.maximum(darr * darr.spec.df * darr.spec.dd * 8, 0.0)) / 2
     amp = amp.transpose(attrs.FREQNAME, attrs.DIRNAME)
 
     # Unpack bins into individual wave components


### PR DESCRIPTION
## Problem

The `to_funwave` and `to_funwave_new` writers compute component amplitudes as

```python
amp = np.sqrt(darr * darr.spec.df * darr.spec.dd * 8) / 2
```

with no lower bound on the energy. Interpolating or rotating a spectrum
(`spec.interp`, `spec.rotate`) can leave near-zero bins with **tiny negative
energy** (~`1e-21`) from floating-point cancellation. These are not NaN, so they
pass typical NaN checks on `efth`, but `sqrt` of a negative value yields `NaN`
amplitudes in the output file.

In practice this produced `NaN` amplitudes in a `WK_NEW_DATA2D` wavemaker file,
which then made the downstream FUNWAVE-TVD run blow up (whole field `NaN` on the
first step).

## Fix

Clip the energy to non-negative before the `sqrt` in **both** writers:

```python
amp = np.sqrt(np.maximum(darr * darr.spec.df * darr.spec.dd * 8, 0.0)) / 2
```

This is behaviour-preserving for all valid (non-negative) input — verified that
amplitudes are identical to the previous expression everywhere it was finite
(max abs diff `0.0`), and the negative bins (energy fraction ~`1e-22` of total,
`ΔHs = 0`) now write as `0.0` instead of `NaN`.

## Tests

Added `test_negative_energy_no_nan`, which injects a tiny negative energy bin and
asserts no `NaN` appears in the output of either writer. Full `test_funwave.py`
suite passes (14 tests).

## Misc

- Bump version `4.5.0` → `4.5.1`.
- Update `HISTORY.rst`: mark `4.5.0` as released (2026-06-16) and add a `4.5.1`
  bug-fix entry.