### PR TITLE
Build and publish binary wheels with cibuildwheel

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -50,7 +50,8 @@ jobs:
       fail-fast: false
       matrix:
         # Native runners for every arch so the built wheels are also tested.
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-latest, windows-latest]
+        # macos-15-intel is the Intel runner label (macos-13 was retired).
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-15-intel, macos-latest, windows-latest]
     steps:
     -
       name: Checkout repo

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -57,7 +57,7 @@ jobs:
       uses: actions/checkout@v4
     -
       name: Build and test wheels
-      uses: pypa/cibuildwheel@v3
+      uses: pypa/cibuildwheel@v4.1.0
       # Build/test/skip configuration lives in [tool.cibuildwheel] in pyproject.toml
     -
       name: Upload wheels

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -3,6 +3,14 @@ name: Python Packaging and docker build
 on:
   release:
     types: [published]
+  workflow_dispatch:
+  # Build (but never publish) wheels when packaging files change, so wheel
+  # breakage is caught in the PR rather than at release time.
+  pull_request:
+    paths:
+      - '.github/workflows/python-publish.yml'
+      - 'pyproject.toml'
+      - 'setup.py'
 
 env:
   REGISTRY: ghcr.io
@@ -13,14 +21,9 @@ permissions:
   packages: write
 
 jobs:
-  pypi-release:
-    name: Publish release to PyPI
+  test:
+    name: Test the library
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/wavespectra
-    permissions:
-      id-token: write
     steps:
     -
       name: Checkout repo
@@ -29,7 +32,8 @@ jobs:
       name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
+        cache: pip
     -
       name: Install dependencies
       run: |
@@ -37,12 +41,65 @@ jobs:
         pip install . 'wavespectra[extra,test]'
     -
       name: Test wavespectra
-      run: pytest -s -v tests
+      run: pytest -s -v --timeout=300 --timeout-method=thread tests
+
+  build-wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Native runners for every arch so the built wheels are also tested.
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-latest, windows-latest]
+    steps:
     -
-      name: Build package
-      run: |
-        pip install build
-        python -m build -s
+      name: Checkout repo
+      uses: actions/checkout@v4
+    -
+      name: Build and test wheels
+      uses: pypa/cibuildwheel@v3
+      # Build/test/skip configuration lives in [tool.cibuildwheel] in pyproject.toml
+    -
+      name: Upload wheels
+      uses: actions/upload-artifact@v4
+      with:
+        name: wheels-${{ matrix.os }}
+        path: wheelhouse/*.whl
+
+  build-sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+    -
+      name: Checkout repo
+      uses: actions/checkout@v4
+    -
+      name: Build sdist
+      run: pipx run build --sdist
+    -
+      name: Upload sdist
+      uses: actions/upload-artifact@v4
+      with:
+        name: sdist
+        path: dist/*.tar.gz
+
+  pypi-release:
+    name: Publish release to PyPI
+    if: github.event_name == 'release'
+    needs: [test, build-wheels, build-sdist]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/wavespectra
+    permissions:
+      id-token: write
+    steps:
+    -
+      name: Download all distributions
+      uses: actions/download-artifact@v4
+      with:
+        path: dist
+        merge-multiple: true
     -
       name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,17 @@ docs = [
 [tool.setuptools.dynamic]
 version = {attr = "wavespectra.__version__"}
 
+[tool.cibuildwheel]
+# CPython versions matching the supported range in the classifiers.
+build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*"]
+# Skip musl-based linux; can be added later if there is demand.
+skip = ["*-musllinux*"]
+# Test every built wheel by running the partition test module, which
+# exercises the compiled specpart extension end to end.
+test-requires = ["pytest", "netCDF4"]
+test-command = "pytest {project}/tests/test_partition.py -q"
+build-verbosity = 1
+
 [tool.ruff]
 line-length = 88
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,11 @@ docs = [
     "sphinx-gallery",
 ]
 
+[tool.setuptools.packages.find]
+# Explicit include so stray top-level directories created at build time
+# (e.g. cibuildwheel's wheelhouse/) don't break flat-layout auto-discovery.
+include = ["wavespectra*"]
+
 [tool.setuptools.package-data]
 "wavespectra.core" = ["*.yml"]
 "wavespectra.output" = ["*.yml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,9 @@ version = {attr = "wavespectra.__version__"}
 [tool.cibuildwheel]
 # CPython versions matching the supported range in the classifiers.
 build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*"]
+# 64-bit only: 32-bit Windows wheels would be built by default, but core
+# dependencies (e.g. matplotlib) no longer ship win32 wheels to test against.
+archs = ["auto64"]
 # Skip musl-based linux; can be added later if there is demand.
 skip = ["*-musllinux*"]
 # Test every built wheel by running the partition test module, which


### PR DESCRIPTION
Part of the quality-improvement work (Tier 2). The package ships a C extension (`specpart`) but releases have been **sdist-only**, so every `pip install wavespectra` required a C compiler and numpy headers — a real installation barrier, particularly on Windows (ironically the platform the C rewrite was meant to help).

## Changes

**`.github/workflows/python-publish.yml`**
- New `build-wheels` job using `pypa/cibuildwheel@v3` across native runners: linux x86_64 (`ubuntu-latest`), linux aarch64 (`ubuntu-24.04-arm`), macOS x86_64 (`macos-13`), macOS arm64 (`macos-latest`), Windows amd64 (`windows-latest`). Native runners mean **every wheel is tested, not just built**.
- New `build-sdist` job; the publish job downloads all distributions and publishes wheels + sdist together.
- Publishing is gated on `release` events only; the wheel/sdist builds also run on `workflow_dispatch` and on PRs that touch packaging files — so wheel breakage surfaces in review, not at release time. **This PR itself exercises the full matrix.**
- The pre-publish full-test gate is kept (with the pytest timeout safety net).

**`pyproject.toml`** — `[tool.cibuildwheel]`:
- CPython 3.9–3.13 (matching the classifiers), musllinux skipped for now.
- Each built wheel is tested by running `tests/test_partition.py` — the module that exercises the compiled extension end-to-end, including the GH-142 layout-invariance regression tests.

## Verification

- Local `cibuildwheel` run with docker (cp312 manylinux x86_64): wheel builds, and all **32 partition tests pass inside the wheel-test container**.
- numpy ABI: the wheel is built against numpy 2.x headers and verified to import and run correctly on **numpy 1.26** in a clean venv (default `NPY_TARGET_VERSION` backward compatibility).
- The full matrix (10 wheels: 5 platforms × varying python versions... 25 wheels total) runs on this PR via the new `pull_request` trigger — check the *Python Packaging and docker build* workflow on this PR for the results.

## Release notes

Once merged, the next release will automatically ship wheels for all supported platforms; users will no longer need a compiler to install wavespectra.