### PR TITLE
Generalise partition tracking: replace ptm1_track with a track method

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,6 +17,19 @@ ___________________
 
 New Features
 ------------
+* New ``track`` partitioning method replacing ``ptm1_track``, tracking wave systems
+  in time from partitions produced by any of the ``ptm1``, ``ptm2``, ``ptm3`` or
+  ``hp01`` methods (``method`` argument, default ``"ptm1"``). Wind-sea matching
+  thresholds are applied to the leading wind sea partitions of each method (both wind
+  seas in ``ptm2``) and swell thresholds to the remaining ones; ``ptm3`` partitions
+  are unclassified so they are all matched with swell thresholds and wind inputs are
+  not required.
+* The partition tracker now evaluates the time step for each pair of consecutive
+  spectra, so records with gaps or irregular sampling use matching thresholds
+  consistent with the actual time elapsed.
+* Candidate partition pairs are now matched globally in ascending order of their
+  distance in frequency-direction space, making the tracking independent of
+  partition ordering.
 * Rewritten ``hp01`` partitioning method implementing the swell combining criteria of
   `Hanson and Phillips (2001) <https://journals.ametsoc.org/view/journals/atot/18/2/1520-0426_2001_018_0277_aaoosd_2_0_co_2.xml>`_
   and `Hanson et al. (2009) <https://journals.ametsoc.org/view/journals/atot/26/8/2009jtecho650_1.xml>`_
@@ -42,6 +55,13 @@ New Features
 
 Breaking Changes
 ----------------
+* The ``ptm1_track`` method has been replaced by ``track`` (use ``method="ptm1"``
+  for the previous behaviour). The output variables have been renamed for clarity:
+  ``part_id`` is now ``track_id`` and ``npart_id`` is now ``ntracks``.
+* ``match_consecutive_partitions`` now takes per-partition threshold arrays and
+  ``np_track_partitions`` / ``track_partitions`` take an ``nsea`` argument defining
+  the number of leading wind sea partitions; times must be strictly increasing and
+  ``wspd`` is only required when ``nsea > 0``.
 * The experimental ``wstype`` argument of ``hp01`` and the associated
   ``np_hp01_wseabins`` and ``np_hp01_wseafrac_wseabins`` variants have been removed;
   the wind sea is now always defined by the wind-sea fraction criterion as in

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -30,6 +30,12 @@ New Features
 * Candidate partition pairs are now matched globally in ascending order of their
   distance in frequency-direction space, making the tracking independent of
   partition ordering.
+* New ``systems`` option in the ``track`` method to remap the tracked partitions
+  onto a ``wave_system`` dimension in place of ``part``, so each tracked wave system
+  occupies its own index and carries values along the entire time axis, null where
+  the system does not exist. Systems spanning fewer time steps than ``min_duration``
+  can be excluded. The remapping is lazy on dask datasets and is also available as
+  the standalone ``wave_systems`` function.
 * Rewritten ``hp01`` partitioning method implementing the swell combining criteria of
   `Hanson and Phillips (2001) <https://journals.ametsoc.org/view/journals/atot/18/2/1520-0426_2001_018_0277_aaoosd_2_0_co_2.xml>`_
   and `Hanson et al. (2009) <https://journals.ametsoc.org/view/journals/atot/26/8/2009jtecho650_1.xml>`_

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -222,6 +222,7 @@ Internal core functions and objects
    partition.tracking.match_consecutive_partitions
    partition.tracking.np_track_partitions
    partition.tracking.track_partitions
+   partition.tracking.wave_systems
    partition.hanson_and_phillips_2001.combine_partitions_hp01
 
 **attributes module**

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -68,7 +68,7 @@ All methods in the :py:class:`SpecArray` accessor are also available from :py:cl
    partition.partition.Partition.ptm5
    partition.partition.Partition.hp01
    partition.partition.Partition.bbox
-   partition.partition.Partition.ptm1_track
+   partition.partition.Partition.track
 
 
 **Other methods**

--- a/docs/partitioning.rst
+++ b/docs/partitioning.rst
@@ -387,6 +387,35 @@ regions whose identity is already continuous in time, so they are not available 
 tracking. The `ptm3` method has no wind sea classification, all partitions are matched
 with the swell thresholds and wind inputs are not required.
 
+Setting `systems=True` remaps the output onto a `wave_system` dimension in place of
+`part`, so that each tracked wave system occupies its own index and carries values
+along the entire time axis, null where the system does not exist. The time series of
+any wave system can then be extracted with a plain selection:
+
+.. ipython:: python
+    :okwarning:
+
+    dsys = dset.spec.partition.track(
+        wspd=dset.wspd,
+        wdir=dset.wdir,
+        dpt=dset.dpt,
+        method="ptm1",
+        systems=True,
+    )
+    dsys
+    dsys.spec.hs().plot.line(x="time", add_legend=False);
+
+    @savefig partitioning_track_systems.png
+    plt.draw()
+
+The `min_duration` argument excludes wave systems spanning fewer time steps from the
+`systems=True` output (all systems are kept by default). Note that wave systems are
+tracked independently at each site, so the same `wave_system` index at different sites
+corresponds to different, physically unrelated systems, and the `wave_system`
+dimension is sized by the site with the most systems with null padding entries at the
+other sites. The spectra remapping is lazy on dask datasets but the track ids must be
+computed upfront to define the size of the output.
+
 Compare the original partitions with no tracking:
 
 .. ipython:: python

--- a/docs/partitioning.rst
+++ b/docs/partitioning.rst
@@ -16,7 +16,7 @@ version 4 this namespace replaced the previous ``partition`` method, see
 :doc:`migration`):
 
 - :meth:`~wavespectra.partition.partition.Partition.ptm1`
-- :meth:`~wavespectra.partition.partition.Partition.ptm1_track`
+- :meth:`~wavespectra.partition.partition.Partition.track`
 - :meth:`~wavespectra.partition.partition.Partition.ptm2`
 - :meth:`~wavespectra.partition.partition.Partition.ptm3`
 - :meth:`~wavespectra.partition.partition.Partition.ptm4`
@@ -25,8 +25,8 @@ version 4 this namespace replaced the previous ``partition`` method, see
 - :meth:`~wavespectra.partition.partition.Partition.bbox`
 
 The `PTM` methods are named after the convention in the `WAVEWATCHIII`_ spectral wave
-model from which they were derived (`PTM1_TRACK` is a modified version of `PTM1` that
-tracks and merges spectral partitions in time).
+model from which they were derived (`TRACK` runs one of the partitioning methods and
+tracks the partitions in time).
 
 The `HP01` method implements the combining of nearby swell partitions (in spectral
 space) described in `Hanson and Phillips (2001)`_ and `Hanson et al. (2009)`_. Adjacent
@@ -51,10 +51,11 @@ density inside and outside a defined bounding box in spectral space.
      - Watershed with all wind-sea partitions combined into partition 0
      - yes
      - yes
-   * - ``ptm1_track``
-     - As ``ptm1``, with swell partitions tracked and merged in time
-     - yes
-     - yes
+   * - ``track``
+     - Any of ``ptm1``, ``ptm2``, ``ptm3`` or ``hp01``, with the partitions
+       tracked in time into wave systems
+     - as per method
+     - as per method
    * - ``ptm2``
      - As ``ptm1``, with a secondary wind sea split from the swell partitions
      - yes
@@ -355,28 +356,36 @@ result is the same as the PTM1 method.
     plt.draw()
 
 
-PTM1_TRACK
-__________
-PTM1_TRACK extends the `PTM1` method to track the partitions using the evolution of
-peak frequency and peak direction in time. The method returns a partitioned dataset
-with the addition of a couple of extra data variables `part_id` and `npart_id`:
+TRACK
+_____
+TRACK partitions the spectra with any of the `PTM1`, `PTM2`, `PTM3` or `HP01` methods
+and tracks the partitions in time using the evolution of peak frequency and peak
+direction. Wind sea partitions are matched with wind-sea thresholds based on
+fetch-limited growth rates and swell partitions with thresholds based on the swell
+dispersion rate. The method returns the partitioned dataset with two extra data
+variables: `track_id`, identifying the wave system each partition belongs to at each
+time step, and `ntracks`, the number of wave systems tracked:
 
 .. ipython:: python
     :okwarning:
 
     dset = read_ww3("_static/ww3file.nc").isel(site=0, drop=True)
-    dspart = dset.spec.partition.ptm1_track(
+    dspart = dset.spec.partition.track(
         wspd=dset.wspd,
         wdir=dset.wdir,
         dpt=dset.dpt,
+        method="ptm1",
     )
     # Add some spectral parameters to visualise
     dspart = xr.merge([dspart, dspart.spec.stats(["hs", "tp", "dpm"])])
     dspart
 
-These variables track the id of all unique wave systems identified over the time range
-of the input spectra dataset and can be used to combine these systems to yield
-consistent time series.
+The `track_id` variable identifies all unique wave systems over the time range of the
+input spectra dataset and can be used to combine these systems to yield consistent
+time series. The `ptm4`, `ptm5` and `bbox` methods define partitions as fixed spectral
+regions whose identity is already continuous in time, so they are not available for
+tracking. The `ptm3` method has no wind sea classification, all partitions are matched
+with the swell thresholds and wind inputs are not required.
 
 Compare the original partitions with no tracking:
 
@@ -405,12 +414,12 @@ Against the tracked partitions:
     fig, axes = plt.subplots(3, 1, figsize=(10, 10))
 
     # Iterate over each unique wave system
-    for part_id in range(dspart.npart_id.values):
-        ind = np.where(dspart.part_id.values.flatten()==part_id)[0]
+    for track_id in range(int(dspart.ntracks)):
+        ind = np.where(dspart.track_id.values.flatten() == track_id)[0]
         pstats = dspart.stack(tpart=("part", "time")).isel(tpart=ind).sortby("time")
         # Plot stats for this wave system
         for ax, var in zip(axes, ["hs", "tp", "dpm"]):
-            ax.plot(pstats.time, pstats[var], ".-", label=f"Partition {part_id}")
+            ax.plot(pstats.time, pstats[var], ".-", label=f"System {track_id}")
             ax.set_ylabel(var)
     ax.legend()
 

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -409,20 +409,72 @@ class TestPartitionAndTrack(BasePTM):
         stats = dspart.spec.stats(["fp", "dpm"]).load()
         track_partitions(stats, wspd=self.dset.wspd)
 
-    def test_class(self):
-        swells = 2
-        dspart = self.pt.ptm1_track(
-            wspd=self.dset.wspd,
-            wdir=self.dset.wdir,
-            dpt=self.dset.dpt,
-            swells=swells,
-        )
-        assert "part_id" in dspart
-        assert "npart_id" in dspart
+    def _track(self, method, **kwargs):
+        dspart = self.pt.track(method=method, swells=2, **kwargs)
+        assert "track_id" in dspart
+        assert "ntracks" in dspart
         # Force the computation: the tracking kernel runs lazily under dask
         # and never executes if only variable existence is checked.
         dspart = dspart.load()
-        assert (dspart.npart_id.values > 0).all()
+        assert (dspart.ntracks.values > 0).all()
+        # Partitions assigned to a track are all non-null
+        assert ((dspart.track_id < 0) | (dspart.spec.hs() > 0)).all()
+        return dspart
+
+    def test_track_ptm1(self):
+        self._track("ptm1", wspd=self.dset.wspd, wdir=self.dset.wdir, dpt=self.dset.dpt)
+
+    def test_track_ptm2(self):
+        self._track("ptm2", wspd=self.dset.wspd, wdir=self.dset.wdir, dpt=self.dset.dpt)
+
+    def test_track_ptm3_no_wind(self):
+        dspart = self.pt.track(method="ptm3", parts=3)
+        assert "track_id" in dspart
+        dspart = dspart.load()
+        assert (dspart.ntracks.values > 0).all()
+
+    def test_track_hp01(self):
+        self._track("hp01", wspd=self.dset.wspd, wdir=self.dset.wdir, dpt=self.dset.dpt)
+
+    def test_track_hp01_no_wind(self):
+        with pytest.warns(UserWarning):
+            dspart = self.pt.track(method="hp01", swells=2)
+        dspart = dspart.load()
+        assert (dspart.ntracks.values > 0).all()
+
+    def test_track_invalid_method(self):
+        with pytest.raises(ValueError):
+            self.pt.track(method="ptm4")
+
+    def test_track_requires_wspd_for_sea(self):
+        dspart = self.pt.ptm1(
+            wspd=self.dset.wspd,
+            wdir=self.dset.wdir,
+            dpt=self.dset.dpt,
+            swells=2,
+        )
+        stats = dspart.spec.stats(["fp", "dpm"]).load()
+        with pytest.raises(ValueError):
+            track_partitions(stats, wspd=None, nsea=1)
+        track_partitions(stats, wspd=None, nsea=0)
+
+    def test_track_unsorted_times_raise(self):
+        from wavespectra.partition.tracking import np_track_partitions
+
+        dspart = self.pt.ptm1(
+            wspd=self.dset.wspd,
+            wdir=self.dset.wdir,
+            dpt=self.dset.dpt,
+            swells=2,
+        )
+        stats = dspart.spec.stats(["fp", "dpm"]).isel(site=0).load()
+        with pytest.raises(ValueError):
+            np_track_partitions(
+                times=stats.time.values[::-1],
+                fp=stats.fp.values.T,
+                dpm=stats.dpm.values.T,
+                wspd=self.dset.wspd.isel(site=0).values,
+            )
 
 
 class TestSpecpartKernel:

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -476,6 +476,57 @@ class TestPartitionAndTrack(BasePTM):
                 wspd=self.dset.wspd.isel(site=0).values,
             )
 
+    def _track_kwargs(self):
+        return dict(
+            wspd=self.dset.wspd, wdir=self.dset.wdir, dpt=self.dset.dpt, swells=2
+        )
+
+    def test_track_systems(self):
+        compact = self.pt.track(method="ptm1", **self._track_kwargs()).load()
+        systems = self.pt.track(
+            method="ptm1", systems=True, **self._track_kwargs()
+        ).load()
+        assert "wave_system" in systems.dims
+        assert "part" not in systems.dims
+        assert systems.wave_system.size == int(compact.ntracks.max())
+        # The total energy at each time step is preserved by the remapping
+        hs_systems = (systems.spec.hs() ** 2).sum("wave_system") ** 0.5
+        hs_compact = (compact.spec.hs() ** 2).sum("part") ** 0.5
+        assert np.allclose(hs_systems.values, hs_compact.values, rtol=1e-5)
+        # Each system exists over a single contiguous time window
+        alive = systems.efth.notnull().any(["freq", "dir"])
+        for a in alive.stack(k=["site", "wave_system"]).transpose("k", "time").values:
+            if a.any():
+                assert np.all(np.diff(np.flatnonzero(a)) == 1)
+        # Padding entries for sites with fewer systems are null with id -999
+        null_systems = ~alive.any("time")
+        assert bool(((systems.track_id == -999) == null_systems).all())
+
+    def test_track_systems_min_duration(self):
+        systems = self.pt.track(
+            method="ptm1", systems=True, **self._track_kwargs()
+        ).load()
+        filtered = self.pt.track(
+            method="ptm1", systems=True, min_duration=3, **self._track_kwargs()
+        ).load()
+        assert filtered.wave_system.size < systems.wave_system.size
+        alive = filtered.efth.notnull().any(["freq", "dir"]).sum("time")
+        assert bool(((filtered.track_id < 0) | (alive >= 3)).all())
+
+    def test_track_systems_lazy(self):
+        dset = self.dset.chunk({"time": 3})
+        systems = dset.spec.partition.track(
+            method="ptm1",
+            systems=True,
+            wspd=dset.wspd,
+            wdir=dset.wdir,
+            dpt=dset.dpt,
+            swells=2,
+        )
+        # The spectra remapping is lazy on dask data
+        assert hasattr(systems.efth.data, "dask")
+        assert bool(systems.load().efth.notnull().any())
+
 
 class TestSpecpartKernel:
     """Regression tests for the specpart C extension (GH issue #142).

--- a/wavespectra/partition/partition.py
+++ b/wavespectra/partition/partition.py
@@ -20,7 +20,7 @@ from wavespectra.core.utils import (
 from wavespectra.core.attributes import attrs
 from wavespectra.core import npstats
 from wavespectra.partition.hanson_and_phillips_2001 import combine_partitions_hp01
-from wavespectra.partition.tracking import track_partitions
+from wavespectra.partition.tracking import track_partitions, wave_systems
 
 
 DEFAULTS = {
@@ -835,6 +835,8 @@ class Partition:
         ddpm_swell_max=20,
         dfp_sea_scaling=1,
         dfp_swell_source_distance=1e6,
+        systems=False,
+        min_duration=1,
         **kwargs,
     ):
         """Partition the spectra and track the wave systems over time.
@@ -872,6 +874,15 @@ class Partition:
               difference for wind sea partitions. Default is 1.
             - dfp_swell_source_distance (float): Distance to source for swell peak
               frequency difference. Default is 1e6 m.
+            - systems (bool): If True, remap the output onto a `wave_system`
+              dimension in place of `part` so that each tracked wave system
+              occupies its own index and carries values along the entire time
+              axis, null where the system does not exist. If False (default),
+              return the partitioned spectra with the `track_id` variable
+              identifying the wave system of each partition at each time step.
+            - min_duration (int): Minimum number of time steps a wave system
+              must span to be included in the `systems=True` output. The
+              default of 1 keeps all tracked systems.
             - kwargs: Further arguments passed to the partitioning method, e.g.
               `swells`, `agefac`, `wscut`, `smooth` or the hp01 combining
               parameters.
@@ -881,7 +892,10 @@ class Partition:
               ordered according to the partitioning method, plus the variable
               `track_id` identifying the wave system each partition belongs to at
               each time step and the variable `ntracks` with the number of wave
-              systems tracked.
+              systems tracked. If `systems` is True the spectra are instead
+              organised along a `wave_system` dimension replacing `part`, with
+              the `track_id` variable mapping each wave system back to its id
+              in the `systems=False` output.
 
         Note:
             - Wind sea partitions (partition 0 in ptm1 and hp01, partitions 0
@@ -892,6 +906,14 @@ class Partition:
             - The time step is evaluated for each pair of consecutive spectra
               so records with gaps or irregular sampling use matching
               thresholds consistent with the actual time elapsed.
+            - Wave systems are tracked independently at each site so with
+              `systems=True` the same `wave_system` index at different sites
+              corresponds to different, physically unrelated systems, and the
+              `wave_system` dimension is sized by the site with the most
+              systems with null padding entries at the other sites.
+            - The spectra remapping with `systems=True` is lazy on dask
+              datasets but the track ids must be computed upfront to define
+              the size of the output.
 
         """
         wind_kwargs = {"wspd": wspd, "wdir": wdir, "dpt": dpt}
@@ -932,8 +954,14 @@ class Partition:
             nsea=nsea,
         )
 
-        # Add track ids to partition data and return
-        return xr.merge([dspart, tracks])
+        # Add track ids to partition data
+        dsout = xr.merge([dspart, tracks])
+
+        # Remap onto the wave_system dimension
+        if systems:
+            dsout = wave_systems(dsout, min_duration=min_duration)
+
+        return dsout
 
 
 def np_ptm1(

--- a/wavespectra/partition/partition.py
+++ b/wavespectra/partition/partition.py
@@ -69,8 +69,8 @@ class Partition:
           Phillips (2001) and Hanson et al. (2009). Useful for noisy measured spectra which the watershed
           algorithm tends to over-segment, and to prescribe an exact number of output partitions.
         - bbox: BBOX partitions the spectra based on user-defined bounding boxes in frequency-direction space.
-        - ptm1_track: Partition spectra using the PTM1 method and track the partitions using the evolution of
-          peak frequency and peak direction in time.
+        - track: Partition spectra using any of the ptm1, ptm2, ptm3 or hp01 methods and track
+          the partitions using the evolution of peak frequency and peak direction in time.
 
     References:
         - Hanson and Phillips (2001), Automated Analysis of Ocean Surface Directional Wave Spectra,
@@ -825,100 +825,115 @@ class Partition:
 
         return dsout.fillna(0.0)
 
-    def ptm1_track(
+    def track(
         self,
-        wspd,
-        wdir,
-        dpt,
-        agefac=DEFAULTS["agefac"],
-        wscut=DEFAULTS["wscut"],
-        swells=DEFAULTS["swells"],
-        smooth=DEFAULTS["smooth"],
-        freq_window=DEFAULTS["window"],
-        dir_window=DEFAULTS["window"],
-        ihmax=DEFAULTS["ihmax"],
+        wspd=None,
+        wdir=None,
+        dpt=None,
+        method="ptm1",
         ddpm_sea_max=30,
         ddpm_swell_max=20,
         dfp_sea_scaling=1,
         dfp_swell_source_distance=1e6,
+        **kwargs,
     ):
-        """Partition and combine spectra from the same wave system over time.
+        """Partition the spectra and track the wave systems over time.
 
-        Partition spectra using the PTM1 method and track the partitions
-        using the evolution of peak frequency and peak direction. Partitions are
-        matched with the closest partition in the frequency-direction space of the
-        previous time step for which the difference in direction with less than
-        ddpm_max and the difference in peak frequency is less than dfp_max. ddpm_max
-        differs for sea and swell partitions and is set manually. dfp_max also differs
-        for sea and swell partitions. In the case of sea partitions it is a function of
-        wind speed and is set to the rate of change of the wind-sea peak wave frequency
-        estimated from fetch-limited relationships, (Ewans & Kibblewhite, 1986). In the
-        case of swell partitions it is set to the rate of change of the swell peak wave
-        frequency based on the swell dispersion relationship derived by
-        Snodgrass et al (1966) assuming the distance to the source is 1e6 m.
+        Partition spectra using any of the watershed partitioning methods and
+        track the partitions using the evolution of peak frequency and peak
+        direction. Partitions are matched with the closest partition in the
+        frequency-direction space of the previous time step for which the
+        difference in direction is less than ddpm_max and the difference in
+        peak frequency is less than dfp_max. ddpm_max differs for sea and swell
+        partitions and is set manually. dfp_max also differs for sea and swell
+        partitions. In the case of sea partitions it is a function of wind
+        speed and is set to the rate of change of the wind-sea peak wave
+        frequency estimated from fetch-limited relationships (Ewans &
+        Kibblewhite, 1986). In the case of swell partitions it is set to the
+        rate of change of the swell peak wave frequency based on the swell
+        dispersion relationship derived by Snodgrass et al (1966) assuming the
+        distance to the source is 1e6 m.
 
         Args:
-            - wspd (xr.DataArray): Wind speed DataArray.
-            - wdir (xr.DataArray): Wind direction DataArray.
-            - dpt (xr.DataArray): Depth DataArray.
-            - swells (int): Number of swell partitions to compute. If None, the
-              number required to hold all swells detected from all spectra is
-              used, which doubles the compute time and triggers an eager
-              computation on dask datasets.
-            - agefac (float): Age factor.
-            - wscut (float): Wind sea fraction cutoff.
-            - smooth (bool): Compute watershed boundaries from smoothed spectra
-              as described in Portilla et al., 2009.
-            - freq_window (int): Size of running window along `freq` for smoothing spectra.
-            - dir_window (int): Size of running window along `dir` for smoothing spectra.
-            - ihmax (int): Number of discrete spectral levels in WW3 Watershed code.
-            - ddpm_sea_max (float): Maximum peak direction difference for wind sea partition.
-              Default is 30 degrees.
-            - ddpm_swell_max (float): Maximum peak direction difference for swell partitions.
-              Default is 20 degrees.
-            - dfp_sea_scaling (float): Scaling factor for maximum peak frequency difference
-              for wind sea partition. Default is 1.
-            - dfp_swell_source_distance (float): Distance to source for swell peak frequency
-              difference. Default is 1e6 m.
+            - wspd (xr.DataArray): Wind speed DataArray, required by the ptm1
+              and ptm2 methods and optional for hp01.
+            - wdir (xr.DataArray): Wind direction DataArray, as above.
+            - dpt (xr.DataArray): Depth DataArray, as above.
+            - method (str): Partitioning method to track partitions from,
+              one of "ptm1", "ptm2", "ptm3" or "hp01". The ptm4, ptm5 and bbox
+              methods define partitions as fixed spectral regions whose
+              identity is already continuous in time, so there is nothing
+              to track.
+            - ddpm_sea_max (float): Maximum peak direction difference for wind sea
+              partitions. Default is 30 degrees.
+            - ddpm_swell_max (float): Maximum peak direction difference for swell
+              partitions. Default is 20 degrees.
+            - dfp_sea_scaling (float): Scaling factor for maximum peak frequency
+              difference for wind sea partitions. Default is 1.
+            - dfp_swell_source_distance (float): Distance to source for swell peak
+              frequency difference. Default is 1e6 m.
+            - kwargs: Further arguments passed to the partitioning method, e.g.
+              `swells`, `agefac`, `wscut`, `smooth` or the hp01 combining
+              parameters.
 
         Returns:
             - dspart (xr.Dataset): Partitioned spectra with extra `part` dimension
-              where the 0th index are the wind sea and remaining indices are the swells
-              sorted by descending order of Hs. Plus array `part_id` containing an integer
-              representing the partition id for each time step and partition. Plus array
-              `npart_id` containing the existing partition ids.
+              ordered according to the partitioning method, plus the variable
+              `track_id` identifying the wave system each partition belongs to at
+              each time step and the variable `ntracks` with the number of wave
+              systems tracked.
+
+        Note:
+            - Wind sea partitions (partition 0 in ptm1 and hp01, partitions 0
+              and 1 in ptm2) are matched with wind-sea thresholds and the
+              remaining partitions with swell thresholds. The ptm3 partitions
+              are not classified and are all matched with swell thresholds,
+              which makes wind inputs optional for that method.
+            - The time step is evaluated for each pair of consecutive spectra
+              so records with gaps or irregular sampling use matching
+              thresholds consistent with the actual time elapsed.
 
         """
+        wind_kwargs = {"wspd": wspd, "wdir": wdir, "dpt": dpt}
+        if method in ("ptm1", "ptm2"):
+            check_same_coordinates(wspd, wdir, dpt)
+            nsea = 1 if method == "ptm1" else 2
+        elif method == "hp01":
+            # hp01 skips the wind sea classification without wind inputs
+            if wspd is None or wdir is None or dpt is None:
+                wind_kwargs = {}
+                nsea = 0
+            else:
+                nsea = 1
+        elif method == "ptm3":
+            # ptm3 partitions are not classified, tracking does not need wind
+            wind_kwargs = {}
+            nsea = 0
+        else:
+            raise ValueError(
+                f"Cannot track partitions from method '{method}', "
+                "available methods are 'ptm1', 'ptm2', 'ptm3' and 'hp01'"
+            )
 
         # Do the partitioning
-        dspart = self.ptm1(
-            wspd=wspd,
-            wdir=wdir,
-            dpt=dpt,
-            agefac=agefac,
-            wscut=wscut,
-            swells=swells,
-            smooth=smooth,
-            freq_window=freq_window,
-            dir_window=dir_window,
-            ihmax=ihmax,
-        )
+        dspart = getattr(self, method)(**wind_kwargs, **kwargs)
 
         # Calculate peak frequency and peak direction
         stats = dspart.spec.stats(["fp", "dpm"])
 
         # Track partitions
-        part_ids = track_partitions(
+        tracks = track_partitions(
             stats,
-            wspd=wspd,
+            wspd=wspd if nsea > 0 else None,
             ddpm_sea_max=ddpm_sea_max,
             ddpm_swell_max=ddpm_swell_max,
             dfp_sea_scaling=dfp_sea_scaling,
             dfp_swell_source_distance=dfp_swell_source_distance,
+            nsea=nsea,
         )
 
-        # Add partition ids to partition data and return
-        return xr.merge([dspart, part_ids])
+        # Add track ids to partition data and return
+        return xr.merge([dspart, tracks])
 
 
 def np_ptm1(

--- a/wavespectra/partition/tracking.py
+++ b/wavespectra/partition/tracking.py
@@ -377,3 +377,108 @@ def track_partitions(
     }
 
     return tracks
+
+
+def wave_systems(dspart, min_duration=1):
+    """Remap tracked partitions onto a wave_system dimension.
+
+    Reorganise a dataset of tracked partitions, as returned by the `track`
+    partitioning method, so that each tracked wave system occupies its own
+    index along a new `wave_system` dimension in place of `part`. Each system
+    carries values along the entire time axis, taken from whichever partition
+    holds the system at each time step and null elsewhere, so the time series
+    of any wave system can be extracted with a plain selection, e.g.
+    `dsout.isel(wave_system=5)`.
+
+    Parameters
+    ----------
+    dspart: xr.Dataset
+        Tracked partitioned dataset with the `efth` and `track_id` variables,
+        as returned by the `track` partitioning method.
+    min_duration: int
+        Minimum number of time steps a wave system must span to be included
+        in the output. The default of 1 keeps all tracked systems.
+
+    Returns
+    -------
+    dsout: xr.Dataset
+        Dataset with the spectra of each tracked wave system along the
+        `wave_system` dimension, null where the system does not exist, and
+        the variable `track_id` mapping each wave system back to its id in
+        the input dataset.
+
+    Notes
+    -----
+    - Systems are ordered chronologically by their first appearance.
+    - Wave systems are tracked independently at each site so the same
+      `wave_system` index at different sites corresponds to different,
+      physically unrelated systems. The size of the `wave_system` dimension
+      accommodates the site with the most systems and the extra entries at
+      the other sites are null, with `track_id` set to -999.
+    - The spectra remapping is lazy on dask datasets but the track ids must
+      be computed upfront to define the size of the output.
+
+    """
+    from wavespectra.core.attributes import attrs, set_spec_attributes
+
+    track_id = dspart.track_id.compute()
+    extra_dims = [d for d in track_id.dims if d not in ("part", "time")]
+    tid = track_id.transpose("part", "time", *extra_dims).values
+    npart, ntime = tid.shape[:2]
+    shape_extra = tid.shape[2:]
+    tid = tid.reshape(npart, ntime, -1)
+
+    # Map each wave system onto the partition index holding it at each time,
+    # independently for each extra (non-time) dim such as site
+    indexers = []
+    system_ids = []
+    for ie in range(tid.shape[-1]):
+        ids, counts = np.unique(tid[..., ie][tid[..., ie] >= 0], return_counts=True)
+        ids = ids[counts >= min_duration]
+        indexer = np.full((ids.size, ntime), -1, dtype="int64")
+        for isys, id_ in enumerate(ids):
+            ipart, itime = np.nonzero(tid[..., ie] == id_)
+            indexer[isys, itime] = ipart
+        indexers.append(indexer)
+        system_ids.append(ids)
+
+    # Pad so all extra dims share the same number of wave systems
+    nsystems = max(ids.size for ids in system_ids)
+    indexer = np.full((nsystems, ntime, tid.shape[-1]), -1, dtype="int64")
+    ids = np.full((nsystems, tid.shape[-1]), -999, dtype="int32")
+    for ie in range(tid.shape[-1]):
+        indexer[: indexers[ie].shape[0], :, ie] = indexers[ie]
+        ids[: system_ids[ie].size, ie] = system_ids[ie]
+
+    # Remap the spectra onto the wave_system dimension, this is lazy on dask
+    # data as it uses vectorised indexing
+    dims = ("wave_system", "time", *extra_dims)
+    coords = {"time": dspart.time}
+    coords.update({d: dspart[d] for d in extra_dims if d in dspart.coords})
+    indexer = xr.DataArray(
+        indexer.reshape((nsystems, ntime, *shape_extra)), dims=dims, coords=coords
+    )
+    efth = dspart[attrs.SPECNAME].isel(part=indexer.clip(min=0)).where(indexer >= 0)
+
+    # Finalise output
+    dsout = efth.to_dataset(name=attrs.SPECNAME)
+    dsout["track_id"] = xr.DataArray(
+        ids.reshape((nsystems, *shape_extra)),
+        dims=("wave_system", *extra_dims),
+    )
+    dsout["wave_system"] = np.arange(nsystems)
+    set_spec_attributes(dsout)
+    dsout.track_id.attrs = {
+        "long_name": "Wave system track ID",
+        "units": "1",
+        "description": (
+            "ID of each wave system in the tracked partitioned dataset, "
+            "-999 for null padding entries"
+        ),
+        "_FillValue": -999,
+    }
+    dsout.wave_system.attrs = {
+        "long_name": "Wave system",
+        "description": "Tracked wave systems ordered by first appearance",
+    }
+    return dsout

--- a/wavespectra/partition/tracking.py
+++ b/wavespectra/partition/tracking.py
@@ -13,9 +13,11 @@ def dfp_wsea(wspd: float, fp: float, dt: float, scaling: float = 1.0) -> float:
 
     Parameters
     ----------
-    wspd: xr.DataArray
+    wspd: float
         Wind speed (m/s)
-    t: float
+    fp: float
+        Peak wave frequency (Hz)
+    dt: float
         Time duration (s)
     scaling: float
         Scaling parameter
@@ -39,21 +41,23 @@ def dfp_swell(dt: float, distance: float = 1e6) -> float:
 
     Parameters
     ----------
-    dt: xr.DataArray
-        Time difference
-    distance: xr.DataArray
+    dt: float
+        Time difference (s)
+    distance: float
         Distance to the swell source (m)
 
     """
     return dt * g / (4 * pi * distance)
 
 
-def match_consecutive_partitions(
-    fp, dpm, dfp_sea_max, dfp_swell_max, ddpm_sea_max, ddpm_swell_max
-):
+def match_consecutive_partitions(fp, dpm, dfp_max, dfp_min, ddpm_max):
     """
     Match partitions of consecutive spectra based on evolution of peak frequency
     and peak direction.
+
+    Candidate pairs within the thresholds are assigned in ascending order of
+    their normalised distance in frequency-direction space so that the closest
+    pairs are always matched first, independently of partition ordering.
 
     Parameters
     ----------
@@ -63,20 +67,21 @@ def match_consecutive_partitions(
     dpm: np.ndarray
         Array containing the mean peak wave direction for all partitions and
         the two consecutive time steps. Shape (npartitions, 2).
-    dfp_sea_max: float
-        Maximum delta fp for sea partitions.
-    dfp_swell_max: float
-        Maximum delta fp for swell partitions.
-    ddpm_sea_max: float
-        Maximum delta dpm for sea partitions.
-    ddpm_swell_max: float
-        Maximum delta dpm for swell partitions.
+    dfp_max: np.ndarray
+        Maximum (most positive) delta fp for a match onto each partition of the
+        previous time step, shape (npartitions,).
+    dfp_min: np.ndarray
+        Minimum (most negative) delta fp for a match onto each partition of the
+        previous time step, shape (npartitions,).
+    ddpm_max: np.ndarray
+        Maximum absolute delta dpm for a match onto each partition of the
+        previous time step, shape (npartitions,).
 
     Returns
     -------
     matches: np.ndarray
         Array of matches between partitions of consecutive spectra.
-        Array contains value in nth position contains the partition number in
+        The value in the nth position contains the partition number in
         the previous time step that matches the partition number n in the
         current time step.
         -999 is for nans and -888 is for partitions that have no match.
@@ -84,7 +89,7 @@ def match_consecutive_partitions(
     """
 
     # Initialise matches to -999
-    matches = np.ones_like(fp[:, 0], dtype="int16") * -999
+    matches = np.ones_like(fp[:, 0], dtype="int32") * -999
 
     # Calculation distance between partitions of the two consecutive time steps
     # Calculate angle difference between current and previous partition
@@ -105,48 +110,31 @@ def match_consecutive_partitions(
         fp[:, 0].reshape((1, -1)), fp.shape[0], axis=0
     )
 
-    # Pick angle threshold based on partition type
-    ddpm_max = np.array([ddpm_sea_max] + [ddpm_swell_max] * (dpm.shape[0] - 1))
-    # If the partition was a sea partition we expect a negative delta
-    # hence we use the swell partition maximum delta as a maximum threshold
-    dfp_max = np.array([dfp_swell_max] * fp.shape[0])
-    # Minimum threshold is based on the sea/swell partition maximum delta
-    # depending on the partition type
-    dfp_min = np.array([dfp_sea_max] + [-dfp_swell_max] * (fp.shape[0] - 1))
+    # For all partition matches which are within the thresholds calculate the
+    # distance between the two partitions as the sum of normalised dfp and ddpm,
+    # the thresholds are aligned with the previous partitions (columns)
+    with np.errstate(invalid="ignore"):
+        within = (ddpm < ddpm_max) & (dfp < dfp_max) & (dfp > dfp_min)
+        partition_distance = np.where(
+            within,
+            np.abs(dfp) / np.maximum(dfp_max, np.abs(dfp_min)) + ddpm / ddpm_max,
+            np.inf,
+        )
 
-    # For all partition matches which are within the thresholds
-    # calculate the distance between the two partitions the sum
-    # of normalized dfp and ddpm
-    partition_distance = np.where(
-        np.logical_and(ddpm < ddpm_max, np.logical_and(dfp < dfp_max, dfp > dfp_min)),
-        (np.abs(dfp) / np.maximum(dfp_max, np.abs(dfp_min)) + ddpm / ddpm_max),
-        999,
-    )
+    # Partitions with no energy at each time step cannot be matched
+    partition_distance[np.isnan(fp[:, 1]), :] = np.inf
+    partition_distance[:, np.isnan(fp[:, 0])] = np.inf
 
-    # Those are all the partitions in the previous time step that have energy
-    available = [
-        ip for ip, fp_is_not_nan in enumerate(~np.isnan(fp[:, 0])) if fp_is_not_nan
-    ]
+    # Mark all energetic partitions in the current time step as unmatched
+    matches[~np.isnan(fp[:, 1])] = -888
 
-    # Loop over all partitions in the current time step
-    for ip_curr, fp_curr in enumerate(fp[:, 1]):
-        if ~np.isnan(fp_curr):
-            # Find all possible matches for the current partition sorted by increasing distance
-            part_matches = sorted(
-                [
-                    (ip_prev, d)
-                    for ip_prev, d in enumerate(partition_distance[ip_curr, :])
-                    if d != 999 and ip_prev in available
-                ],
-                key=lambda x: x[-1],
-            )
-
-            # If no match found, create new partition to track
-            if len(part_matches) == 0:
-                matches[ip_curr] = -888
-            else:  # If match found mark it and remove it from the available list
-                matches[ip_curr] = part_matches[0][0]
-                available.remove(part_matches[0][0])
+    # Assign candidate pairs globally in ascending order of distance so that
+    # the closest pairs are matched first
+    icurr, iprev = np.nonzero(partition_distance < np.inf)
+    order = np.argsort(partition_distance[icurr, iprev], kind="stable")
+    for ic, ip in zip(icurr[order], iprev[order]):
+        if matches[ic] == -888 and ip not in matches:
+            matches[ic] = ip
 
     return matches
 
@@ -155,11 +143,12 @@ def np_track_partitions(
     times,
     fp,
     dpm,
-    wspd,
+    wspd=None,
     ddpm_sea_max=30,
     ddpm_swell_max=20,
     dfp_sea_scaling=1,
     dfp_swell_source_distance=1e6,
+    nsea=1,
 ):
     """
     Track partitions at a site in a series of consecutive spectra based on
@@ -180,11 +169,11 @@ def np_track_partitions(
     times: np.ndarray
         Array containing the time stamps of the spectra statistics.
     fp: np.ndarray
-        Array containing the peak wave frequency.
+        Array containing the peak wave frequency with shape (npart, ntime).
     dpm: np.ndarray
-        Array containing the mean peak wave direction.
+        Array containing the peak wave direction with shape (npart, ntime).
     wspd: np.ndarray
-        Wind speed at 10 metres (m/s).
+        Wind speed at 10 metres (m/s), required if nsea > 0.
     ddpm_sea_max: float
         Maximum delta dpm for sea partitions.
         Default is 30 degrees.
@@ -197,76 +186,92 @@ def np_track_partitions(
     dfp_swell_source_distance: float
         Distance to the swell source (m) for the rate of change of the swell peak wave
         frequency. Default is 1e6 m.
+    nsea: int
+        Number of leading partitions that represent wind seas, e.g., 1 for
+        partitions from the ptm1 and hp01 methods, 2 for the ptm2 method and 0
+        for the ptm3 method whose partitions are not classified. Wind-sea
+        matching thresholds are applied to the first nsea partitions and swell
+        thresholds to the remaining ones.
 
     Returns
     -------
-    part_ids: np.ndarray
-        Array containing the partition ids for each partition and each time step.
+    track_ids: np.ndarray
+        Array containing the track ids for each partition and each time step.
         -999 is for nans.
-    n_parts: int
-        Number of partitions tracked.
+    ntracks: int
+        Number of wave systems tracked.
+
+    Notes
+    -----
+    The time step is evaluated for each pair of consecutive spectra so records
+    with gaps or irregular sampling use matching thresholds consistent with the
+    actual time elapsed.
 
     """
+    if np.any(np.diff(times) <= np.timedelta64(0, "s")):
+        raise ValueError("times must be strictly increasing to track partitions")
+    nsea = min(nsea, fp.shape[0])
+    if nsea > 0 and wspd is None:
+        raise ValueError("wspd is required to track wind sea partitions (nsea > 0)")
 
-    # Assuming that the time step is constant across the dataset
-    # calculate dt in seconds
-    dt = float((times[1] - times[0]) / np.timedelta64(1, "s"))
-
-    # Calculate maximum delta fp for sea partitions
-    # as it is a function of wind speed this is a data array
-    dfp_sea_max = dfp_wsea(wspd=wspd, fp=fp[0, :], dt=dt, scaling=dfp_sea_scaling)
-
-    # Calculate maximum delta fp for swell partitions
-    # it is a scalar
-    dfp_swell_max = dfp_swell(dt=dt, distance=dfp_swell_source_distance)
+    npart = fp.shape[0]
+    ddpm_max = np.array([ddpm_sea_max] * nsea + [ddpm_swell_max] * (npart - nsea))
 
     # Calculate local matches (match partitions between consecutive time steps)
     # -999 is for nans and -888 is for partitions that have no match
-    # This has more potential to be parallelised but the way the xarray dataset
-    # rolling window work makes it non trivial
-    part_ids = np.hstack(
-        [np.ones((fp.shape[0], 1), dtype="int16") * -999]
-        + [
+    matches = [np.ones((npart, 1), dtype="int32") * -999]
+    for it in range(1, times.shape[0]):
+        dt = float((times[it] - times[it - 1]) / np.timedelta64(1, "s"))
+        dfp_swell_max = dfp_swell(dt=dt, distance=dfp_swell_source_distance)
+        # The delta fp thresholds are asymmetric for wind seas: fp is expected
+        # to decrease under growing seas at the fetch-limited rate, and to only
+        # increase slowly under decaying seas at the swell dispersion rate
+        dfp_min = np.full(npart, -dfp_swell_max)
+        for ip in range(nsea):
+            dfp_min[ip] = dfp_wsea(
+                wspd=wspd[it - 1], fp=fp[ip, it - 1], dt=dt, scaling=dfp_sea_scaling
+            )
+        dfp_max = np.full(npart, dfp_swell_max)
+        matches.append(
             match_consecutive_partitions(
                 fp=fp[:, it - 1 : it + 1],
                 dpm=dpm[:, it - 1 : it + 1],
-                dfp_sea_max=dfp_sea_max[it - 1],
-                dfp_swell_max=dfp_swell_max,
-                ddpm_sea_max=ddpm_sea_max,
-                ddpm_swell_max=ddpm_swell_max,
+                dfp_max=dfp_max,
+                dfp_min=dfp_min,
+                ddpm_max=ddpm_max,
             ).reshape((-1, 1))
-            for it in range(1, times.shape[0])
-        ]
-    )
+        )
+    track_ids = np.hstack(matches)
 
-    # Turn the local matches into global matches
-    part_id = 0  # Partitions are numbered from 0
+    # Turn the local matches into global track ids
+    track_id = 0  # Tracks are numbered from 0
 
     # Number the partitions in the first time step
     for ip, vfp in enumerate(fp[:, 0]):
         if ~np.isnan(vfp):
-            part_ids[ip, 0] = part_id
-            part_id += 1
+            track_ids[ip, 0] = track_id
+            track_id += 1
 
-    # Propagate the partition ids through time
+    # Propagate the track ids through time
     for it in range(1, times.size):
         for ip in range(fp.shape[0]):
-            if part_ids[ip, it] == -888:
-                part_ids[ip, it] = part_id
-                part_id += 1
-            elif part_ids[ip, it] != -999:
-                part_ids[ip, it] = part_ids[part_ids[ip, it], it - 1]
+            if track_ids[ip, it] == -888:
+                track_ids[ip, it] = track_id
+                track_id += 1
+            elif track_ids[ip, it] != -999:
+                track_ids[ip, it] = track_ids[track_ids[ip, it], it - 1]
 
-    return part_ids, part_id
+    return track_ids, track_id
 
 
 def track_partitions(
     stats,
-    wspd,
+    wspd=None,
     ddpm_sea_max=30,
     ddpm_swell_max=20,
     dfp_sea_scaling=1,
     dfp_swell_source_distance=1e6,
+    nsea=1,
 ):
     """
     Track partitions in a series of consecutive spectra based on
@@ -287,7 +292,8 @@ def track_partitions(
     stats: xr.Dataset
         Statistics of the spectral partitions. Requires fp and dpm.
     wspd: xr.DataArray
-        Wind speed (m/s). Time/site should match that of stats.
+        Wind speed (m/s), required if nsea > 0. Time/site should match that
+        of stats.
     ddpm_sea_max: float
         Maximum delta dpm for sea partitions.
         Default is 30 degrees.
@@ -300,16 +306,28 @@ def track_partitions(
     dfp_swell_source_distance: float
         Distance to the swell source (m) for the rate of change of the swell peak wave
         frequency. Default is 1e6 m.
+    nsea: int
+        Number of leading partitions that represent wind seas, e.g., 1 for
+        partitions from the ptm1 and hp01 methods, 2 for the ptm2 method and 0
+        for the ptm3 method whose partitions are not classified. Wind-sea
+        matching thresholds are applied to the first nsea partitions and swell
+        thresholds to the remaining ones.
 
     Returns
     -------
-    part_ids: xr.Dataset
-        Dataset containing the partition ids for each partition and each time step.
+    tracks: xr.Dataset
+        Dataset with the `track_id` of each partition at each time step and the
+        number of wave systems tracked `ntracks`.
 
     """
+    if nsea > 0 and wspd is None:
+        raise ValueError("wspd is required to track wind sea partitions (nsea > 0)")
+    if wspd is None:
+        # Placeholder so the wind can be broadcast by apply_ufunc, not used
+        wspd = xr.full_like(stats["fp"].isel(part=0, drop=True), np.nan)
 
     # Track partitions
-    part_ids, npart_id = xr.apply_ufunc(
+    track_id, ntracks = xr.apply_ufunc(
         np_track_partitions,
         stats.time,
         stats.fp,
@@ -319,6 +337,7 @@ def track_partitions(
         ddpm_swell_max,
         dfp_sea_scaling,
         dfp_swell_source_distance,
+        nsea,
         input_core_dims=[
             ["time"],
             ["part", "time"],
@@ -328,29 +347,33 @@ def track_partitions(
             [],
             [],
             [],
+            [],
         ],
         output_core_dims=[["part", "time"], []],
         vectorize=True,
         dask="parallelized",
-        output_dtypes=[np.int16, "int"],
+        output_dtypes=[np.int32, "int"],
         dask_gufunc_kwargs={"allow_rechunk": True},
     )
 
     # Finalise output
-    part_ids = part_ids.to_dataset(name="part_id")
-    part_ids["npart_id"] = npart_id
+    tracks = track_id.to_dataset(name="track_id")
+    tracks["ntracks"] = ntracks
 
     # Add metadata
-    part_ids.part_id.attrs = {
-        "long_name": "Partition ID",
+    tracks.track_id.attrs = {
+        "long_name": "Wave system track ID",
         "units": "1",
-        "description": "ID of tracked partition",
+        "description": (
+            "ID of the tracked wave system each partition belongs to, "
+            "-999 for null partitions"
+        ),
         "_FillValue": -999,
     }
-    part_ids.npart_id.attrs = {
-        "long_name": "Number of partitions",
+    tracks.ntracks.attrs = {
+        "long_name": "Number of wave systems",
         "units": "1",
-        "description": "Number of partitions tracked for a given non-spectral dim",
+        "description": "Number of wave systems tracked over the time series",
     }
 
-    return part_ids
+    return tracks


### PR DESCRIPTION
## Summary

Replaces `ptm1_track` with a generic **`track`** method that partitions the spectra with any of the `ptm1`, `ptm2`, `ptm3` or `hp01` methods (`method` argument, default `"ptm1"`) and tracks the resulting partitions in time. Tracking is conceptually orthogonal to the partitioning method — this removes the accidental PTM1 coupling and makes temporal continuity available for the `hp01` combined partitions, whose stable, order-invariant output is the best input for tracking.

### Tracker generalisation

The matching previously hard-coded partition 0 as the wind sea. A new `nsea` argument defines how many leading partitions take the wind-sea matching thresholds:

- `ptm1` / `hp01`: 1 (unchanged behaviour for ptm1)
- `ptm2`: 2 — the secondary wind sea was previously matched with swell thresholds
- `ptm3`: 0 — partitions are unclassified, all matched with swell thresholds, and wind inputs are no longer required (Met Office-style PTM3 + temporal consolidation, cf. Bunney & Saulter 2015)

`ptm4`, `ptm5` and `bbox` are excluded: their partitions are fixed spectral regions whose identity is already continuous in time.

### Robustness fixes to the matching algorithm

- **Per-step time step**: `dt` was taken from the first two timestamps only, so records with gaps applied e.g. 30-minute thresholds across a 6-hour gap. The thresholds are now computed for each pair of consecutive spectra; times are validated to be strictly increasing.
- **Order-invariant matching**: candidate pairs were assigned greedily in slot order, so a partition could steal a later partition's true match. Pairs are now assigned globally in ascending order of their normalised frequency-direction distance.
- Track ids stored as `int32` (int16 could overflow on long noisy records).

### Output naming

The output variables are renamed for clarity: `part_id` → `track_id` ("ID of the tracked wave system each partition belongs to") and `npart_id` → `ntracks`. A remapped `wave_system`-dimensioned output view was considered and deliberately deferred: it is the more intuitive layout but its size grows with every transient track, so it needs `min_duration` / `max_systems` filters — left as a follow-up pending design agreement.

### Breaking changes

`ptm1_track` is removed (it was recent and little used); use `track(method="ptm1")`. `track_partitions` / `np_track_partitions` gain the `nsea` argument and `match_consecutive_partitions` now takes per-partition threshold arrays. Changelog entries added under the unreleased 4.6.0 section.

### Testing

New accessor tests for tracking through each supported method (including ptm3/hp01 without wind and the wind-required/invalid-method errors), unsorted-times validation, and functional checks on irregular (gappy) records and dask-backed data. Full suite: 381 passed; docs build warning-clean.