### PR TITLE
Add dataset_transforms option gating the Dataset-aware transforms with a FutureWarning

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,35 @@ changelog covers the release history since v3.0 when wavespectra was open-source
 Releases
 ********
 
+5.0.0 (unreleased)
+___________________
+
+Breaking Changes
+----------------
+* Methods that transform the spectral variable (``interp``, ``interp_like``,
+  ``smooth``, ``split``, ``oned``, ``rotate``, ``to_energy``, ``scale_by_hs`` and
+  the partitioning methods in the ``spec.partition`` namespace) now return a
+  ``Dataset`` instead of a ``DataArray`` when called from the Dataset accessor,
+  carrying the non-spectral variables (e.g. ``wspd``, ``wdir``, ``dpt``) from the
+  source dataset which were previously silently dropped. The DataArray accessor
+  is unchanged, e.g. ``dset.efth.spec.oned()`` still returns a DataArray.
+  Variables that depend on the spectral dims other than the spectral variable
+  itself are dropped from the output since their coordinates may no longer be
+  consistent with the transformed spectra. Methods that reduce the spectra into
+  parameters such as ``hs`` and ``tp`` are unaffected and still return a named
+  DataArray from both accessors.
+
+New Features
+------------
+* The ``wspd``, ``wdir`` and ``dpt`` arguments of the ``ptm1``, ``ptm2``, ``ptm4``,
+  ``hp01`` and ``track`` partitioning methods now default to the variables with
+  those names in the underlying dataset when partitioning from a Dataset, e.g.
+  ``dset.spec.partition.ptm1()``.
+
+Internal Changes
+----------------
+* ``rmse`` now accepts a Dataset in the ``other`` argument.
+
 4.6.0 (2026-07-08)
 ___________________
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,9 +17,10 @@ ___________________
 
 Breaking Changes
 ----------------
-* Methods that transform the spectral variable (``interp``, ``interp_like``,
+* The ``dataset_transforms`` behaviour introduced in 4.7.0 becomes the default:
+  methods that transform the spectral variable (``interp``, ``interp_like``,
   ``smooth``, ``split``, ``oned``, ``rotate``, ``to_energy``, ``scale_by_hs`` and
-  the partitioning methods in the ``spec.partition`` namespace) now return a
+  the partitioning methods in the ``spec.partition`` namespace) return a
   ``Dataset`` instead of a ``DataArray`` when called from the Dataset accessor,
   carrying the non-spectral variables (e.g. ``wspd``, ``wdir``, ``dpt``) from the
   source dataset which were previously silently dropped. The DataArray accessor
@@ -29,13 +30,38 @@ Breaking Changes
   consistent with the transformed spectra. Methods that reduce the spectra into
   parameters such as ``hs`` and ``tp`` are unaffected and still return a named
   DataArray from both accessors.
+* The ``wspd``, ``wdir`` and ``dpt`` arguments of the ``hp01`` and ``track``
+  partitioning methods now default to the variables with those names in the
+  underlying dataset when partitioning from a Dataset.
+
+4.7.0 (unreleased)
+___________________
 
 New Features
 ------------
-* The ``wspd``, ``wdir`` and ``dpt`` arguments of the ``ptm1``, ``ptm2``, ``ptm4``,
-  ``hp01`` and ``track`` partitioning methods now default to the variables with
-  those names in the underlying dataset when partitioning from a Dataset, e.g.
-  ``dset.spec.partition.ptm1()``.
+* New ``wavespectra.set_options`` / ``wavespectra.get_options`` functions to set
+  package-level options globally or within a context block. The first supported
+  option is ``dataset_transforms`` which opts in to the future behaviour where
+  methods that transform the spectral variable (``interp``, ``interp_like``,
+  ``smooth``, ``split``, ``oned``, ``rotate``, ``to_energy``, ``scale_by_hs`` and
+  the partitioning methods in the ``spec.partition`` namespace) return a
+  ``Dataset`` preserving the non-spectral variables when called from the Dataset
+  accessor. This will become the default behaviour in wavespectra 5.0; until
+  then, calling these methods from the Dataset accessor without the option set
+  emits a ``FutureWarning`` and returns the bare spectral DataArray as before.
+* The ``wspd``, ``wdir`` and ``dpt`` arguments of the ``ptm1``, ``ptm2`` and
+  ``ptm4`` partitioning methods now default to the variables with those names in
+  the underlying dataset when partitioning from a Dataset, e.g.
+  ``dset.spec.partition.ptm1()``. The same defaults apply to ``hp01`` and
+  ``track`` only when the ``dataset_transforms`` option is set, since falling
+  back on dataset wind would change the wind sea classification of existing code
+  calling these methods without wind arguments.
+
+Bug Fixes
+---------
+* ``read_triaxys`` now returns a Dataset as documented when reading with
+  ``magnetic_variation`` and ``regrid_dir=True`` (previously it returned a
+  DataArray in that case).
 
 Internal Changes
 ----------------

--- a/docs/construction.rst
+++ b/docs/construction.rst
@@ -141,7 +141,7 @@ Compare against real frequency spectrum (with gamma adjusted for a good fit):
     @suppress
     fig, ax = plt.subplots(1, 1, figsize=(6, 4))
 
-    ds.spec.oned().plot(ax=ax, label="Original spectrum");
+    ds.efth.spec.oned().plot(ax=ax, label="Original spectrum");
     ds_construct.plot(ax=ax, label="Jonswap");
 
     @suppress
@@ -168,7 +168,7 @@ If the :math:`Hs` parameter is provided it is used to scale the Jonswap spectrum
     def label(dset):
         return f"$Hs={float(dset.spec.hs()):0.2f}m$)"
 
-    ds.spec.oned().plot(ax=ax, label=f"Original spectrum ({label(ds)}");
+    ds.efth.spec.oned().plot(ax=ax, label=f"Original spectrum ({label(ds)}");
     ds1.plot(ax=ax, label=f"Jonswap scaled by $\\alpha$ ({label(ds1)}");
     ds2.plot(ax=ax, label=f"Jonswap scaled by $Hs$ ({label(ds2)}");
 
@@ -355,7 +355,7 @@ Compare shapes for all times in the first swell partition:
 
     # Original spectra
     ax = fig.add_subplot(311)
-    ds = dspart.spec.oned().isel(part=1).transpose("freq", "time")
+    ds = dspart.efth.spec.oned().isel(part=1).transpose("freq", "time")
     ds.plot.contourf(cmap=cmap, levels=20, ylim=(0.02, 0.4), vmax=4.0);
 
     @suppress

--- a/docs/construction_2d.rst
+++ b/docs/construction_2d.rst
@@ -287,10 +287,10 @@ one-dimensional spectrum :math:`E_d(f)` integrated from existing :math:`E_d(f,d)
     )
 
     # Apply directional distributions to the one-dimensional spectrum
-    dscart = dset.spec.oned() * c
-    dsasym = dset.spec.oned() * a
+    dscart = dset.efth.spec.oned() * c
+    dsasym = dset.efth.spec.oned() * a
 
-    dsall = xr.concat([dset, dscart, dsasym], dim="fit")
+    dsall = xr.concat([dset.efth, dscart, dsasym], dim="fit")
     dsall["fit"] = ["Original", "Cartwright", "Asymmetric"]
     dsall.spec.plot(
         figsize=(12, 5),

--- a/docs/gallery/plot_spectra_timeseries.py
+++ b/docs/gallery/plot_spectra_timeseries.py
@@ -15,7 +15,7 @@ fig = plt.figure(figsize=(8, 4))
 
 dset = read_ww3("../_static/ww3file.nc")
 ds = dset.isel(site=0).spec.split(fmax=0.18)
-ds = ds.spec.oned().rename({"freq": "period"})
+ds = ds.efth.spec.oned().rename({"freq": "period"})
 ds = ds.assign_coords({"period": 1 / ds.period})
 ds.period.attrs.update({"standard_name": "sea_surface_wave_period", "units": "s"})
 p = ds.plot.contourf(

--- a/docs/partitioning.rst
+++ b/docs/partitioning.rst
@@ -39,10 +39,14 @@ combined until the requested number is reached.
 The `BBOX` method is a custom method to split the energy
 density inside and outside a defined bounding box in spectral space.
 
-When partitioning from a Dataset, the output is a Dataset carrying the non-spectral
-variables from the source dataset, and the ``wspd``, ``wdir`` and ``dpt`` arguments
-default to the dataset variables with those names so the methods that require them
-can be called without arguments, e.g. ``dset.spec.partition.ptm1()``. When
+When partitioning from a Dataset with the ``dataset_transforms`` option set with
+``wavespectra.set_options(dataset_transforms=True)``, the output is a Dataset
+carrying the non-spectral variables from the source dataset, and the ``wspd``,
+``wdir`` and ``dpt`` arguments default to the dataset variables with those names so
+the methods that require them can be called without arguments, e.g.
+``dset.spec.partition.ptm1()``. This will become the default behaviour in
+wavespectra 5.0; until then, partitioning from a Dataset without the option set
+returns the partitioned spectra as a DataArray and emits a ``FutureWarning``. When
 partitioning from a DataArray, the partitioned spectra are returned as a DataArray
 and the wind and depth arguments must be prescribed.
 

--- a/docs/partitioning.rst
+++ b/docs/partitioning.rst
@@ -39,6 +39,13 @@ combined until the requested number is reached.
 The `BBOX` method is a custom method to split the energy
 density inside and outside a defined bounding box in spectral space.
 
+When partitioning from a Dataset, the output is a Dataset carrying the non-spectral
+variables from the source dataset, and the ``wspd``, ``wdir`` and ``dpt`` arguments
+default to the dataset variables with those names so the methods that require them
+can be called without arguments, e.g. ``dset.spec.partition.ptm1()``. When
+partitioning from a DataArray, the partitioned spectra are returned as a DataArray
+and the wind and depth arguments must be prescribed.
+
 .. list-table::
    :header-rows: 1
    :widths: 14 46 20 20

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -258,7 +258,7 @@ Plotting Hovmoller diagrams of frequency spectra time series can be done in only
     @suppress
     plt.figure(figsize=(8, 4))
 
-    ds = dset.isel(site=0).spec.split(fmax=0.18).spec.oned().rename({"freq": "period"})
+    ds = dset.isel(site=0).spec.split(fmax=0.18).efth.spec.oned().rename({"freq": "period"})
     ds = ds.assign_coords({"period": 1 / ds.period})
     ds.period.attrs.update({"standard_name": "sea_surface_wave_period", "units": "s"})
 

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -153,7 +153,7 @@ def test_interp_spec(dset):
     interp_spec(inspec, inf, ind, outfreq=outf, outdir=outd, method="cubic")
     interp_spec(inspec, inf, ind, outfreq=outf, outdir=outd, method="nearest")
     # 1D spectra
-    inspec = dset.isel(lat=0, lon=0, time=0).spec.oned().values
+    inspec = dset.isel(lat=0, lon=0, time=0).efth.spec.oned().values
     interp_spec(inspec, inf, indir=None, outfreq=None, outdir=None, method="linear")
     interp_spec(inspec, inf, indir=None, outfreq=outf, outdir=None, method="linear")
 

--- a/tests/core/test_npstats.py
+++ b/tests/core/test_npstats.py
@@ -27,7 +27,7 @@ def test_hs(dset):
 
 def test_dpm(dset):
     ds = dset.isel(time=0, site=0, drop=True)
-    ipeak = ds.efth.spec._peak(ds.spec.oned())
+    ipeak = ds.efth.spec._peak(ds.efth.spec.oned())
     momsin, momcos = ds.spec.momd(1)
     out = dpm(int(ipeak), momsin.values, momcos.values)
     assert np.isclose(out, 249.09263611)
@@ -37,7 +37,7 @@ def test_dpm(dset):
 
 def test_dp(dset):
     ds = dset.isel(time=0, site=0, drop=True)
-    ipeak = np.int64(ds.efth.spec._peak(ds.spec.oned()))
+    ipeak = np.int64(ds.efth.spec._peak(ds.efth.spec.oned()))
     dir = ds.dir.values.astype("float32")
     out = dp(ipeak, dir)
     assert np.isclose(out, 55)
@@ -45,8 +45,8 @@ def test_dp(dset):
 
 def test_tps(dset):
     ds = dset.isel(time=0, site=0, drop=True)
-    ipeak = np.int64(ds.efth.spec._peak(ds.spec.oned()))
-    spectrum = ds.spec.oned().values.astype("float64")
+    ipeak = np.int64(ds.efth.spec._peak(ds.efth.spec.oned()))
+    spectrum = ds.efth.spec.oned().values.astype("float64")
     freq = ds.freq.values.astype("float32")
     out = tps(ipeak, spectrum, freq)
     assert np.isclose(out, 12.907742)
@@ -56,8 +56,8 @@ def test_tps(dset):
 
 def test_tp(dset):
     ds = dset.isel(time=0, site=0, drop=True)
-    ipeak = np.int64(ds.efth.spec._peak(ds.spec.oned()))
-    spectrum = ds.spec.oned().values.astype("float64")
+    ipeak = np.int64(ds.efth.spec._peak(ds.efth.spec.oned()))
+    spectrum = ds.efth.spec.oned().values.astype("float64")
     freq = ds.freq.values.astype("float32")
     out = tp(ipeak, spectrum, freq)
     assert np.isclose(out, 13.568521)
@@ -67,7 +67,7 @@ def test_tp(dset):
 
 def test_dpspr(dset):
     ds = dset.isel(time=0, site=0, drop=True)
-    ipeak = np.int64(ds.efth.spec._peak(ds.spec.oned()))
+    ipeak = np.int64(ds.efth.spec._peak(ds.efth.spec.oned()))
     fdspr1 = ds.spec.fdspr(mom=1).values.astype("float64")
     fdspr2 = ds.spec.fdspr(mom=2).values.astype("float64")
 

--- a/tests/core/test_regrid.py
+++ b/tests/core/test_regrid.py
@@ -2,11 +2,19 @@ import pytest
 from pathlib import Path
 import numpy as np
 
+import wavespectra
 from wavespectra import read_triaxys, read_ww3
 from wavespectra.core.utils import regrid_spec
 
 
 FILES_DIR = Path(__file__).parent.parent / "sample_files"
+
+
+@pytest.fixture(autouse=True)
+def dataset_transforms():
+    """Run under the future dataset transforms behaviour in this module."""
+    with wavespectra.set_options(dataset_transforms=True):
+        yield
 
 
 @pytest.fixture(scope="module")

--- a/tests/core/test_xrstats.py
+++ b/tests/core/test_xrstats.py
@@ -13,6 +13,15 @@ from wavespectra.core.xrstats import (
 FILES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../sample_files")
 
 
+@pytest.fixture(autouse=True)
+def dataset_transforms():
+    """Run under the future dataset transforms behaviour in this module."""
+    import wavespectra
+
+    with wavespectra.set_options(dataset_transforms=True):
+        yield
+
+
 @pytest.fixture(scope="module")
 def dset():
     """Load SpecDset but skip test if matplotlib is not installed."""

--- a/tests/io/test_funwave.py
+++ b/tests/io/test_funwave.py
@@ -180,7 +180,7 @@ class TestFunwave:
         * Read it back and check stats and dimension consistency.
         """
         filename = os.path.join(self.tmp_dir, "fw_new_roundtrip_1d.txt")
-        dset0 = self.dsww3.isel(time=0, site=0, drop=True).spec.oned().to_dataset()
+        dset0 = self.dsww3.isel(time=0, site=0, drop=True).spec.oned()
         dset0.spec.to_funwave_new(filename, clip=False)
         dset1 = read_funwave_new(filename)
         assert dset1.spec.dd == 1
@@ -194,7 +194,7 @@ class TestFunwave:
     def test_new_data2d_1d(self):
         """Write oned wave component file with all directions set to zero."""
         filename = os.path.join(self.tmp_dir, "fw_new_1d.txt")
-        dset0 = self.dsww3.isel(time=0, site=0, drop=True).spec.oned().to_dataset()
+        dset0 = self.dsww3.isel(time=0, site=0, drop=True).spec.oned()
         dset0.spec.to_funwave_new(filename, clip=False)
         nc, tp, freq, dire, amp, phase = self._read_new_data2d(filename)
         assert nc == dset0.freq.size
@@ -232,7 +232,7 @@ class TestFunwave:
         * Check for dimension consistency.
         """
         filename = os.path.join(self.tmp_dir, "fw1d.txt")
-        dset0 = self.dsww3.isel(time=0, site=0, drop=True).spec.oned().to_dataset()
+        dset0 = self.dsww3.isel(time=0, site=0, drop=True).spec.oned()
         dset0.spec.to_funwave(filename, clip=False)
         dset1 = read_funwave(filename)
         assert dset1.spec.dd == 1

--- a/tests/io/test_funwave.py
+++ b/tests/io/test_funwave.py
@@ -180,7 +180,7 @@ class TestFunwave:
         * Read it back and check stats and dimension consistency.
         """
         filename = os.path.join(self.tmp_dir, "fw_new_roundtrip_1d.txt")
-        dset0 = self.dsww3.isel(time=0, site=0, drop=True).spec.oned()
+        dset0 = self.dsww3.isel(time=0, site=0, drop=True).efth.spec.oned().to_dataset()
         dset0.spec.to_funwave_new(filename, clip=False)
         dset1 = read_funwave_new(filename)
         assert dset1.spec.dd == 1
@@ -194,7 +194,7 @@ class TestFunwave:
     def test_new_data2d_1d(self):
         """Write oned wave component file with all directions set to zero."""
         filename = os.path.join(self.tmp_dir, "fw_new_1d.txt")
-        dset0 = self.dsww3.isel(time=0, site=0, drop=True).spec.oned()
+        dset0 = self.dsww3.isel(time=0, site=0, drop=True).efth.spec.oned().to_dataset()
         dset0.spec.to_funwave_new(filename, clip=False)
         nc, tp, freq, dire, amp, phase = self._read_new_data2d(filename)
         assert nc == dset0.freq.size
@@ -232,7 +232,7 @@ class TestFunwave:
         * Check for dimension consistency.
         """
         filename = os.path.join(self.tmp_dir, "fw1d.txt")
-        dset0 = self.dsww3.isel(time=0, site=0, drop=True).spec.oned()
+        dset0 = self.dsww3.isel(time=0, site=0, drop=True).efth.spec.oned().to_dataset()
         dset0.spec.to_funwave(filename, clip=False)
         dset1 = read_funwave(filename)
         assert dset1.spec.dd == 1

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -2,6 +2,7 @@ import pytest
 from pathlib import Path
 import numpy as np
 
+import wavespectra
 from wavespectra import read_ww3
 from wavespectra.partition.partition import (
     Partition,
@@ -16,6 +17,13 @@ from wavespectra.partition.tracking import track_partitions
 
 
 HERE = Path(__file__).parent
+
+
+@pytest.fixture(autouse=True)
+def dataset_transforms():
+    """Run under the future dataset transforms behaviour in this module."""
+    with wavespectra.set_options(dataset_transforms=True):
+        yield
 
 
 class BasePTM:

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -437,9 +437,16 @@ class TestPartitionAndTrack(BasePTM):
         self._track("hp01", wspd=self.dset.wspd, wdir=self.dset.wdir, dpt=self.dset.dpt)
 
     def test_track_hp01_no_wind(self):
+        # Wind variables are resolved from the dataset so partitioning from
+        # the DataArray is required to exercise the no-wind path
+        pt = Partition(self.dset.efth)
         with pytest.warns(UserWarning):
-            dspart = self.pt.track(method="hp01", swells=2)
+            dspart = pt.track(method="hp01", swells=2)
         dspart = dspart.load()
+        assert (dspart.ntracks.values > 0).all()
+
+    def test_track_hp01_wind_from_dataset(self):
+        dspart = self.pt.track(method="hp01", swells=2).load()
         assert (dspart.ntracks.values > 0).all()
 
     def test_track_invalid_method(self):

--- a/tests/test_specdataset.py
+++ b/tests/test_specdataset.py
@@ -1,0 +1,129 @@
+"""Testing the dataset-aware behaviour of the SpecDataset accessor."""
+
+import os
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from wavespectra import read_ww3
+from wavespectra.partition.partition import Partition
+
+
+FILES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sample_files")
+
+TRANSFORMS = {
+    "oned": {},
+    "split": {"fmin": 0.05, "fmax": 0.4},
+    "smooth": {},
+    "rotate": {"angle": 30},
+    "interp": {"freq": np.arange(0.04, 0.4, 0.02)},
+    "to_energy": {},
+    "scale_by_hs": {"expr": "2 * hs"},
+}
+
+
+@pytest.fixture(scope="module")
+def dset():
+    yield read_ww3(os.path.join(FILES_DIR, "ww3file.nc"))
+
+
+@pytest.mark.parametrize("method, kwargs", TRANSFORMS.items())
+def test_transform_returns_dataset_with_variables(dset, method, kwargs):
+    """Dataset accessor transforms return Dataset with non-spectral variables."""
+    dsout = getattr(dset.spec, method)(**kwargs)
+    assert isinstance(dsout, xr.Dataset)
+    for name in ["wspd", "wdir", "dpt", "lat", "lon"]:
+        assert name in dsout.data_vars
+
+
+@pytest.mark.parametrize("method, kwargs", TRANSFORMS.items())
+def test_transform_dataarray_accessor_unchanged(dset, method, kwargs):
+    """DataArray accessor transforms still return a DataArray with same values."""
+    darr = getattr(dset.efth.spec, method)(**kwargs)
+    assert isinstance(darr, xr.DataArray)
+    dsout = getattr(dset.spec, method)(**kwargs)
+    specname = "energy" if method == "to_energy" else "efth"
+    assert dsout[specname].values == pytest.approx(darr.values, nan_ok=True)
+
+
+def test_interp_like_returns_dataset(dset):
+    dsout = dset.spec.interp_like(dset.efth)
+    assert isinstance(dsout, xr.Dataset)
+    assert "wspd" in dsout.data_vars
+    assert isinstance(dset.efth.spec.interp_like(dset.efth), xr.DataArray)
+
+
+def test_transform_drops_spectral_variables(dset):
+    """Extra variables that depend on spectral dims are dropped."""
+    ds = dset.copy()
+    ds["extra"] = ds.efth * 2
+    dsout = ds.spec.smooth()
+    assert "extra" not in dsout
+    assert "wspd" in dsout.data_vars
+
+
+def test_transform_keeps_dataset_attrs(dset):
+    ds = dset.copy()
+    ds.attrs["title"] = "test title"
+    assert ds.spec.oned().attrs["title"] == "test title"
+
+
+def test_scalar_params_still_dataarray(dset):
+    assert isinstance(dset.spec.hs(), xr.DataArray)
+    assert isinstance(dset.spec.stats(["hs", "tp"]), xr.Dataset)
+
+
+def test_transform_chaining(dset):
+    dsout = dset.spec.split(fmax=0.2).spec.oned()
+    assert isinstance(dsout, xr.Dataset)
+    assert "wspd" in dsout.data_vars
+
+
+class TestPartitionDatasetAware:
+    def test_partition_returns_dataset(self, dset):
+        dspart = dset.spec.partition.ptm1(swells=2)
+        assert isinstance(dspart, xr.Dataset)
+        for name in ["wspd", "wdir", "dpt"]:
+            assert name in dspart.data_vars
+        assert "part" in dspart.efth.dims
+
+    def test_partition_wind_defaults_from_dataset(self, dset):
+        implicit = dset.spec.partition.ptm1(swells=2)
+        explicit = dset.spec.partition.ptm1(
+            wspd=dset.wspd, wdir=dset.wdir, dpt=dset.dpt, swells=2
+        )
+        xr.testing.assert_allclose(implicit, explicit)
+
+    @pytest.mark.parametrize("method", ["ptm2", "ptm4"])
+    def test_partition_wind_defaults_other_methods(self, dset, method):
+        dspart = getattr(dset.spec.partition, method)()
+        assert isinstance(dspart, xr.Dataset)
+
+    def test_partition_dataarray_returns_dataarray(self, dset):
+        dspart = dset.efth.spec.partition.ptm1(
+            wspd=dset.wspd, wdir=dset.wdir, dpt=dset.dpt, swells=2
+        )
+        assert isinstance(dspart, xr.DataArray)
+
+    def test_partition_wind_required_without_dataset(self, dset):
+        with pytest.raises(ValueError):
+            dset.efth.spec.partition.ptm1()
+
+    def test_partition_no_wind_dims(self, dset):
+        dspart = dset.spec.partition.ptm5(fcut=0.1)
+        assert isinstance(dspart, xr.Dataset)
+        assert "wspd" in dspart.data_vars
+
+    def test_track_returns_dataset_with_variables(self, dset):
+        dsout = dset.spec.partition.track(swells=2)
+        assert isinstance(dsout, xr.Dataset)
+        for name in ["efth", "track_id", "ntracks", "wspd", "wdir", "dpt"]:
+            assert name in dsout.data_vars
+
+    def test_track_dataarray_no_extra_variables(self, dset):
+        dsout = Partition(dset.efth).track(
+            wspd=dset.wspd, wdir=dset.wdir, dpt=dset.dpt, swells=2
+        )
+        assert isinstance(dsout, xr.Dataset)
+        assert "wspd" not in dsout.data_vars

--- a/tests/test_specdataset.py
+++ b/tests/test_specdataset.py
@@ -6,11 +6,19 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from wavespectra import read_ww3
+from wavespectra import read_ww3, set_options, get_options
 from wavespectra.partition.partition import Partition
 
 
 FILES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sample_files")
+
+
+@pytest.fixture(autouse=True)
+def dataset_transforms():
+    """Opt in to the future dataset transforms behaviour in this module."""
+    with set_options(dataset_transforms=True):
+        yield
+
 
 TRANSFORMS = {
     "oned": {},
@@ -127,3 +135,58 @@ class TestPartitionDatasetAware:
         )
         assert isinstance(dsout, xr.Dataset)
         assert "wspd" not in dsout.data_vars
+
+
+class TestDefaultBehaviour:
+    """Without the dataset_transforms option the old behaviour is preserved."""
+
+    def test_transform_warns_and_returns_dataarray(self, dset):
+        with set_options(dataset_transforms=False):
+            with pytest.warns(FutureWarning, match="oned"):
+                dsout = dset.spec.oned()
+        assert isinstance(dsout, xr.DataArray)
+
+    def test_transform_values_unchanged(self, dset):
+        with set_options(dataset_transforms=False):
+            with pytest.warns(FutureWarning):
+                darr = dset.spec.smooth()
+        xr.testing.assert_allclose(darr, dset.efth.spec.smooth())
+
+    def test_dataarray_accessor_does_not_warn(self, dset):
+        import warnings
+
+        with set_options(dataset_transforms=False):
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", FutureWarning)
+                darr = dset.efth.spec.oned()
+        assert isinstance(darr, xr.DataArray)
+
+    def test_partition_warns_and_returns_dataarray(self, dset):
+        with set_options(dataset_transforms=False):
+            with pytest.warns(FutureWarning, match="Partitioning"):
+                dspart = dset.spec.partition.ptm1(
+                    wspd=dset.wspd, wdir=dset.wdir, dpt=dset.dpt, swells=2
+                )
+        assert isinstance(dspart, xr.DataArray)
+
+    def test_hp01_does_not_default_wind_from_dataset(self, dset):
+        with set_options(dataset_transforms=False):
+            with pytest.warns((FutureWarning, UserWarning)):
+                dspart = dset.spec.partition.hp01(swells=2)
+        assert isinstance(dspart, xr.DataArray)
+        # No wind classification, partition 0 is null
+        assert float(dspart.isel(part=0).sum()) == 0
+
+
+class TestSetOptions:
+    def test_option_toggles_and_restores(self, dset):
+        with set_options(dataset_transforms=False):
+            assert get_options()["dataset_transforms"] is False
+            with set_options(dataset_transforms=True):
+                assert get_options()["dataset_transforms"] is True
+                assert isinstance(dset.spec.oned(), xr.Dataset)
+            assert get_options()["dataset_transforms"] is False
+
+    def test_invalid_option_raises(self):
+        with pytest.raises(ValueError):
+            set_options(not_an_option=True)

--- a/wavespectra/__init__.py
+++ b/wavespectra/__init__.py
@@ -7,6 +7,8 @@
 
 import warnings
 
+from wavespectra.core.options import set_options, get_options
+
 try:
     from wavespectra.specdataset import SpecDataset
     from wavespectra.specarray import SpecArray

--- a/wavespectra/construct/__init__.py
+++ b/wavespectra/construct/__init__.py
@@ -145,7 +145,7 @@ def partition_and_reconstruct(
             if v not in dset.data_vars:
                 raise ValueError(f"Missing variable '{v}' in dset for partitioning.")
         kw = dict(wspd=dset.wspd, wdir=dset.wdir, dpt=dset.dpt, swells=parts - 1)
-    dspart = getattr(dset.spec.partition, partition_method)(**kw)
+    dspart = getattr(dset[attrs.SPECNAME].spec.partition, partition_method)(**kw)
 
     # Calculating parameters
     stats = list(set(STATS) - set(use_defaults))

--- a/wavespectra/core/options.py
+++ b/wavespectra/core/options.py
@@ -1,0 +1,57 @@
+"""Package-level options."""
+
+DATASET_TRANSFORMS = "dataset_transforms"
+
+OPTIONS = {
+    DATASET_TRANSFORMS: False,
+}
+
+
+class set_options:
+    """Set package-level options for wavespectra.
+
+    Can be used either as a function to set options globally or as a context
+    manager to set them within a controlled block, restoring the previous
+    values when exiting the block.
+
+    Currently supported options:
+
+    - ``dataset_transforms``: If True, methods that transform the spectral
+      variable such as ``interp``, ``smooth``, ``split``, ``oned`` and the
+      partitioning methods return a Dataset preserving the non-spectral
+      variables when called from the Dataset accessor, and the ``wspd``,
+      ``wdir`` and ``dpt`` arguments of the ``hp01`` and ``track``
+      partitioning methods default to the dataset variables with those names.
+      If False (default), those methods return a bare spectral DataArray and
+      emit a FutureWarning. This will become the default behaviour in
+      wavespectra 5.0.
+
+    Examples:
+        >>> import wavespectra
+        >>> wavespectra.set_options(dataset_transforms=True)  # global
+        >>> with wavespectra.set_options(dataset_transforms=True):
+        ...     dsout = dset.spec.oned()  # within context only
+
+    """
+
+    def __init__(self, **kwargs):
+        self.old = {}
+        for key, value in kwargs.items():
+            if key not in OPTIONS:
+                raise ValueError(
+                    f"Argument '{key}' is not in the set of valid options "
+                    f"{set(OPTIONS)}"
+                )
+            self.old[key] = OPTIONS[key]
+        OPTIONS.update(kwargs)
+
+    def __enter__(self):
+        return
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        OPTIONS.update(self.old)
+
+
+def get_options():
+    """Return a dictionary with the current package-level options."""
+    return dict(OPTIONS)

--- a/wavespectra/core/utils.py
+++ b/wavespectra/core/utils.py
@@ -280,6 +280,36 @@ def check_same_coordinates(*args):
             )
 
 
+def dataset_from_transform(transformed, dset):
+    """Merge transformed spectral variable back into its source dataset.
+
+    Args:
+        - transformed (DataArray, Dataset): Transformed spectral variable(s)
+          calculated from the spectral variable in dset.
+        - dset (Dataset): Source dataset the transform was calculated from.
+
+    Returns:
+        - dsout (Dataset): Dataset with the transformed spectral variable(s)
+          and the non-spectral variables from dset.
+
+    Note:
+        - Variables in dset that depend on the spectral dims (freq, dir) are
+          dropped since their coordinates may no longer be consistent with
+          those in the transformed spectra.
+
+    """
+    if isinstance(transformed, xr.DataArray):
+        transformed = transformed.to_dataset(name=transformed.name or attrs.SPECNAME)
+    drop_dims = [d for d in (attrs.FREQNAME, attrs.DIRNAME) if d in dset.dims]
+    others = dset.drop_dims(drop_dims)
+    others = others.drop_vars(
+        [v for v in others.data_vars if v in transformed.data_vars]
+    )
+    dsout = xr.merge([transformed, others])
+    dsout.attrs = dset.attrs
+    return dsout
+
+
 def load_function(module_name, func_name, prefix=None):
     """Returns a function object from string.
 

--- a/wavespectra/input/triaxys.py
+++ b/wavespectra/input/triaxys.py
@@ -10,7 +10,7 @@ import xarray as xr
 
 from wavespectra.specdataset import SpecDataset
 from wavespectra.core.attributes import attrs, set_spec_attributes
-from wavespectra.core.utils import interp_spec
+from wavespectra.core.utils import interp_spec, dataset_from_transform
 
 
 def read_triaxys(
@@ -47,7 +47,9 @@ def read_triaxys(
         dset = dset.assign_coords({"dir": dirs + magnetic_variation})
         # Regrid
         if regrid_dir:
-            dset = dset.spec.interp(dir=dirs)
+            dset = dataset_from_transform(
+                dset[attrs.SPECNAME].spec.interp(dir=dirs), dset
+            )
     return dset
 
 

--- a/wavespectra/output/octopus.py
+++ b/wavespectra/output/octopus.py
@@ -107,7 +107,7 @@ def to_octopus(
                 dset.spec.momf(mom=1).rename("momf1"),
                 dset.spec.momf(mom=2).rename("momf2"),
                 dset.spec.momd(mom=0)[0].rename("momd"),
-                dset.spec.to_energy(),
+                dset[attrs.SPECNAME].spec.to_energy(),
                 (dset.efth.spec.df * dset.spec.momd(mom=0)[0])
                 .transpose(attrs.TIMENAME, attrs.SITENAME, attrs.FREQNAME)
                 .rename("fSpec"),

--- a/wavespectra/partition/partition.py
+++ b/wavespectra/partition/partition.py
@@ -12,6 +12,7 @@ from wavespectra.core.utils import (
     regrid_spec,
     smooth_spec,
     check_same_coordinates,
+    dataset_from_transform,
     D2R,
     celerity,
     is_overlap,
@@ -41,6 +42,14 @@ DEFAULTS = {
 
 class Partition:
     """Spectra partition methods.
+
+    Note:
+        - When defined from a Dataset, the partitioning methods return a
+          Dataset carrying the non-spectral variables from the source dataset,
+          and the `wspd`, `wdir` and `dpt` arguments default to the dataset
+          variables with those names. When defined from a DataArray, the
+          partitioned spectra are returned as a DataArray (except for `track`
+          which always returns a Dataset).
 
     Methods:
         - ptm1: In PTM1, topographic partitions for which the percentage of wind-sea energy exceeds a
@@ -91,10 +100,37 @@ class Partition:
     def __init__(self, dset):
         if isinstance(dset, xr.DataArray):
             self.dset = dset
+            self._dset = None
         elif isinstance(dset, xr.Dataset):
             self.dset = dset[attrs.SPECNAME]
+            self._dset = dset
         else:
             raise ValueError("dset needs to be either SpecArray or SpecDataset")
+
+    def _resolve(self, value, name):
+        """Fall back on dataset variable `name` when `value` is not prescribed."""
+        if value is None and self._dset is not None:
+            value = self._dset.get(name)
+        return value
+
+    def _wind_and_depth(self, wspd, wdir, dpt, required=False):
+        """Resolve wind and depth args, falling back on dataset variables."""
+        wspd = self._resolve(wspd, attrs.WSPDNAME)
+        wdir = self._resolve(wdir, attrs.WDIRNAME)
+        dpt = self._resolve(dpt, attrs.DEPNAME)
+        if required and (wspd is None or wdir is None or dpt is None):
+            raise ValueError(
+                "wspd, wdir and dpt are required, either as arguments or as "
+                "variables in the underlying dataset when partitioning from a "
+                "Dataset"
+            )
+        return wspd, wdir, dpt
+
+    def _wrap_output(self, dsout):
+        """Return Dataset with non-spectral variables if defined from a Dataset."""
+        if self._dset is None:
+            return dsout
+        return dataset_from_transform(dsout, self._dset)
 
     def _set_metadata(self, dsout):
         """Define metadata attributes in output."""
@@ -145,9 +181,9 @@ class Partition:
 
     def ptm1(
         self,
-        wspd,
-        wdir,
-        dpt,
+        wspd=None,
+        wdir=None,
+        dpt=None,
         agefac=DEFAULTS["agefac"],
         wscut=DEFAULTS["wscut"],
         swells=DEFAULTS["swells"],
@@ -164,9 +200,12 @@ class Partition:
         swell components in order of decreasing wave height.
 
         Args:
-            - wspd (xr.DataArray): Wind speed DataArray.
-            - wdir (xr.DataArray): Wind direction DataArray.
-            - dpt (xr.DataArray): Depth DataArray.
+            - wspd (xr.DataArray): Wind speed DataArray, taken from the `wspd`
+              variable in the underlying dataset if not provided.
+            - wdir (xr.DataArray): Wind direction DataArray, taken from the
+              `wdir` variable in the underlying dataset if not provided.
+            - dpt (xr.DataArray): Depth DataArray, taken from the `dpt`
+              variable in the underlying dataset if not provided.
             - swells (int): Number of swell partitions to compute. If None, the
               number required to hold all swells detected from all spectra is
               used, which doubles the compute time and triggers an eager
@@ -180,7 +219,7 @@ class Partition:
             - ihmax (int): Number of discrete spectral levels in WW3 Watershed code.
 
         Returns:
-            - dspart (xr.Dataset): Partitioned spectra with extra `part` dimension
+            - dspart (xr.DataArray, xr.Dataset): Partitioned spectra with extra `part` dimension
               where the 0th index are the wind sea and remaining indices are the swells
               sorted by descending order of Hs.
 
@@ -194,6 +233,7 @@ class Partition:
 
         """
         # Sort out inputs
+        wspd, wdir, dpt = self._wind_and_depth(wspd, wdir, dpt, required=True)
         check_same_coordinates(wspd, wdir, dpt)
         if smooth:
             dset_smooth = smooth_spec(self.dset, freq_window, dir_window)
@@ -261,13 +301,13 @@ class Partition:
         }
         dsout.attrs.update(parts_description)
 
-        return dsout.transpose("part", ...)
+        return self._wrap_output(dsout.transpose("part", ...))
 
     def ptm2(
         self,
-        wspd,
-        wdir,
-        dpt,
+        wspd=None,
+        wdir=None,
+        dpt=None,
         agefac=DEFAULTS["agefac"],
         wscut=DEFAULTS["wscut"],
         swells=DEFAULTS["swells"],
@@ -288,9 +328,12 @@ class Partition:
         partition compared to PTM1.
 
         Args:
-            - wspd (xr.DataArray): Wind speed DataArray.
-            - wdir (xr.DataArray): Wind direction DataArray.
-            - dpt (xr.DataArray): Depth DataArray.
+            - wspd (xr.DataArray): Wind speed DataArray, taken from the `wspd`
+              variable in the underlying dataset if not provided.
+            - wdir (xr.DataArray): Wind direction DataArray, taken from the
+              `wdir` variable in the underlying dataset if not provided.
+            - dpt (xr.DataArray): Depth DataArray, taken from the `dpt`
+              variable in the underlying dataset if not provided.
             - swells (int): Number of swell partitions to compute. If None, the
               number required to hold all swells detected from all spectra is
               used, which doubles the compute time and triggers an eager
@@ -304,7 +347,7 @@ class Partition:
             - ihmax (int): Number of discrete spectral levels in WW3 Watershed code.
 
         Returns:
-            - dspart (xr.Dataset): Partitioned spectra with extra `part` dimension
+            - dspart (xr.DataArray, xr.Dataset): Partitioned spectra with extra `part` dimension
               where the 0th and 1st indices are the primary and secondary wind seas
               and remaining indices are the swells sorted by descending order of Hs.
 
@@ -318,6 +361,7 @@ class Partition:
 
         """
         # Sort out inputs
+        wspd, wdir, dpt = self._wind_and_depth(wspd, wdir, dpt, required=True)
         check_same_coordinates(wspd, wdir, dpt)
         if smooth:
             dset_smooth = smooth_spec(self.dset, freq_window, dir_window)
@@ -386,7 +430,7 @@ class Partition:
         }
         dsout.attrs.update(parts_description)
 
-        return dsout.transpose("part", ...)
+        return self._wrap_output(dsout.transpose("part", ...))
 
     def ptm3(
         self,
@@ -418,7 +462,7 @@ class Partition:
             - ihmax (int): Number of discrete spectral levels in WW3 Watershed code.
 
         Returns:
-            - dspart (xr.Dataset): Partitioned spectra with extra `part` dimension
+            - dspart (xr.DataArray, xr.Dataset): Partitioned spectra with extra `part` dimension
               defining watershed partitions sorted by descending order of Hs.
 
         References:
@@ -473,9 +517,9 @@ class Partition:
         dsout = self._set_metadata(dsout)
         dsout.attrs.update({"part0-n": "partitions in descending order of hs"})
 
-        return dsout.transpose("part", ...)
+        return self._wrap_output(dsout.transpose("part", ...))
 
-    def ptm4(self, wspd, wdir, dpt, agefac=DEFAULTS["agefac"]):
+    def ptm4(self, wspd=None, wdir=None, dpt=None, agefac=DEFAULTS["agefac"]):
         """PTM4 WAM partitioning of sea and swell based on wave age criterion..
 
         PTM4 uses the wave age criterion derived from the local wind speed to split the
@@ -486,19 +530,23 @@ class Partition:
         model.
 
         Args:
-            - wspd (xr.DataArray): Wind speed DataArray.
-            - wdir (xr.DataArray): Wind direction DataArray.
-            - dpt (xr.DataArray): Depth DataArray.
+            - wspd (xr.DataArray): Wind speed DataArray, taken from the `wspd`
+              variable in the underlying dataset if not provided.
+            - wdir (xr.DataArray): Wind direction DataArray, taken from the
+              `wdir` variable in the underlying dataset if not provided.
+            - dpt (xr.DataArray): Depth DataArray, taken from the `dpt`
+              variable in the underlying dataset if not provided.
             - agefac (float): Age factor.
 
         Returns:
-            - dspart (xr.Dataset): Partitioned spectra with extra `part` dimension
+            - dspart (xr.DataArray, xr.Dataset): Partitioned spectra with extra `part` dimension
               where the 0th index is the wind sea and the 1st index is the swell.
 
         References:
             - WW3 documentation (https://github.com/NOAA-EMC/WW3).
 
         """
+        wspd, wdir, dpt = self._wind_and_depth(wspd, wdir, dpt, required=True)
         dsout = self.dset.sortby("dir").sortby("freq")
 
         # Masking wind sea and swell regions
@@ -513,7 +561,7 @@ class Partition:
         dsout = self._set_metadata(dsout)
         dsout.attrs.update({"part0": "wind sea", "part1": "swell"})
 
-        return dsout.fillna(0.0)
+        return self._wrap_output(dsout.fillna(0.0))
 
     def ptm5(self, fcut, interpolate=True):
         """PTM5 SWAN partitioning of sea and swell based on user-defined threshold.
@@ -534,7 +582,7 @@ class Partition:
               frequency in the dset.
 
         Returns:
-            - dspart (xr.Dataset): Partitioned spectra with extra `part` dimension
+            - dspart (xr.DataArray, xr.Dataset): Partitioned spectra with extra `part` dimension
               where the 0th index is the wind sea and the 1st index is the swell.
 
         Note:
@@ -565,7 +613,7 @@ class Partition:
         dsout = self._set_metadata(dsout)
         dsout.attrs.update({"part0": "sea", "part1": "swell"})
 
-        return dsout.fillna(0.0)
+        return self._wrap_output(dsout.fillna(0.0))
 
     def hp01(
         self,
@@ -596,9 +644,12 @@ class Partition:
         contain small, non-physical partitions.
 
         Args:
-            - wspd (xr.DataArray): Wind speed DataArray.
-            - wdir (xr.DataArray): Wind direction DataArray.
-            - dpt (xr.DataArray): Depth DataArray.
+            - wspd (xr.DataArray): Wind speed DataArray, taken from the `wspd`
+              variable in the underlying dataset if not provided.
+            - wdir (xr.DataArray): Wind direction DataArray, taken from the
+              `wdir` variable in the underlying dataset if not provided.
+            - dpt (xr.DataArray): Depth DataArray, taken from the `dpt`
+              variable in the underlying dataset if not provided.
             - swells (int): Number of swell partitions to compute. If None, the
               number required to hold all combined swells from all spectra is
               detected in a first pass, which doubles the compute time and
@@ -636,7 +687,7 @@ class Partition:
               from the output.
 
         Returns:
-            - dspart (xr.Dataset): Partitioned spectra with extra `part` dimension
+            - dspart (xr.DataArray, xr.Dataset): Partitioned spectra with extra `part` dimension
               where the 0th index are the wind sea and remaining indices are the swells
               sorted by descending order of Hs.
 
@@ -655,6 +706,7 @@ class Partition:
             - WW3 documentation (https://github.com/NOAA-EMC/WW3).
 
         """
+        wspd, wdir, dpt = self._wind_and_depth(wspd, wdir, dpt)
         check_same_coordinates(wspd, wdir, dpt)
         # Smooth spectra for defining watershed boundaries
         if smooth:
@@ -745,7 +797,7 @@ class Partition:
         }
         dsout.attrs.update(parts_description)
 
-        return dsout.transpose("part", ...)
+        return self._wrap_output(dsout.transpose("part", ...))
 
     def bbox(self, bboxes):
         """Partition based on user-defined bounding boxes in frequency-direction space.
@@ -758,7 +810,7 @@ class Partition:
               `dmin` and `dmax` specifying the boundaries of each bounding box.
 
         Returns:
-            - dspart (xr.Dataset): Partitioned spectra with extra `part` dimension
+            - dspart (xr.DataArray, xr.Dataset): Partitioned spectra with extra `part` dimension
               with indices ordered as in the list of dictionaries.
 
         Note:
@@ -823,7 +875,7 @@ class Partition:
             )
         dsout.attrs.update({f"part{ind + 1}": "complement"})
 
-        return dsout.fillna(0.0)
+        return self._wrap_output(dsout.fillna(0.0))
 
     def track(
         self,
@@ -858,7 +910,8 @@ class Partition:
 
         Args:
             - wspd (xr.DataArray): Wind speed DataArray, required by the ptm1
-              and ptm2 methods and optional for hp01.
+              and ptm2 methods and optional for hp01. Taken from the `wspd`
+              variable in the underlying dataset if not provided.
             - wdir (xr.DataArray): Wind direction DataArray, as above.
             - dpt (xr.DataArray): Depth DataArray, as above.
             - method (str): Partitioning method to track partitions from,
@@ -888,7 +941,7 @@ class Partition:
               parameters.
 
         Returns:
-            - dspart (xr.Dataset): Partitioned spectra with extra `part` dimension
+            - dspart (xr.DataArray, xr.Dataset): Partitioned spectra with extra `part` dimension
               ordered according to the partitioning method, plus the variable
               `track_id` identifying the wave system each partition belongs to at
               each time step and the variable `ntracks` with the number of wave
@@ -916,6 +969,7 @@ class Partition:
               the size of the output.
 
         """
+        wspd, wdir, dpt = self._wind_and_depth(wspd, wdir, dpt)
         wind_kwargs = {"wspd": wspd, "wdir": wdir, "dpt": dpt}
         if method in ("ptm1", "ptm2"):
             check_same_coordinates(wspd, wdir, dpt)
@@ -937,8 +991,9 @@ class Partition:
                 "available methods are 'ptm1', 'ptm2', 'ptm3' and 'hp01'"
             )
 
-        # Do the partitioning
-        dspart = getattr(self, method)(**wind_kwargs, **kwargs)
+        # Do the partitioning, on the spectral variable only so the tracking
+        # is not affected by other variables in the underlying dataset
+        dspart = getattr(Partition(self.dset), method)(**wind_kwargs, **kwargs)
 
         # Calculate peak frequency and peak direction
         stats = dspart.spec.stats(["fp", "dpm"])
@@ -961,7 +1016,7 @@ class Partition:
         if systems:
             dsout = wave_systems(dsout, min_duration=min_duration)
 
-        return dsout
+        return self._wrap_output(dsout)
 
 
 def np_ptm1(

--- a/wavespectra/partition/partition.py
+++ b/wavespectra/partition/partition.py
@@ -19,6 +19,7 @@ from wavespectra.core.utils import (
     waveage,
 )
 from wavespectra.core.attributes import attrs
+from wavespectra.core.options import OPTIONS, DATASET_TRANSFORMS
 from wavespectra.core import npstats
 from wavespectra.partition.hanson_and_phillips_2001 import combine_partitions_hp01
 from wavespectra.partition.tracking import track_partitions, wave_systems
@@ -44,12 +45,15 @@ class Partition:
     """Spectra partition methods.
 
     Note:
-        - When defined from a Dataset, the partitioning methods return a
-          Dataset carrying the non-spectral variables from the source dataset,
-          and the `wspd`, `wdir` and `dpt` arguments default to the dataset
-          variables with those names. When defined from a DataArray, the
-          partitioned spectra are returned as a DataArray (except for `track`
-          which always returns a Dataset).
+        - When defined from a Dataset and the `dataset_transforms` option is
+          set with `wavespectra.set_options(dataset_transforms=True)`, the
+          partitioning methods return a Dataset carrying the non-spectral
+          variables from the source dataset, and the `wspd`, `wdir` and `dpt`
+          arguments of the `hp01` and `track` methods default to the dataset
+          variables with those names. This will become the default behaviour
+          in wavespectra 5.0. When defined from a DataArray, the partitioned
+          spectra are returned as a DataArray (except for `track` which
+          always returns a Dataset).
 
     Methods:
         - ptm1: In PTM1, topographic partitions for which the percentage of wind-sea energy exceeds a
@@ -127,10 +131,29 @@ class Partition:
         return wspd, wdir, dpt
 
     def _wrap_output(self, dsout):
-        """Return Dataset with non-spectral variables if defined from a Dataset."""
+        """Return Dataset with non-spectral variables if defined from a Dataset.
+
+        The Dataset output only takes place if the `dataset_transforms`
+        option is set, otherwise a FutureWarning is emitted and the bare
+        partitioned spectra are returned.
+
+        """
         if self._dset is None:
             return dsout
-        return dataset_from_transform(dsout, self._dset)
+        if OPTIONS[DATASET_TRANSFORMS]:
+            return dataset_from_transform(dsout, self._dset)
+        warnings.warn(
+            "Partitioning from the Dataset accessor will return a Dataset "
+            "preserving the non-spectral variables in wavespectra 5.0. Opt "
+            "in to the future behaviour with "
+            "`wavespectra.set_options(dataset_transforms=True)`, or "
+            "partition from the DataArray accessor, e.g. "
+            "`dset.efth.spec.partition`, to retain the current behaviour "
+            "and silence this warning.",
+            FutureWarning,
+            stacklevel=3,
+        )
+        return dsout
 
     def _set_metadata(self, dsout):
         """Define metadata attributes in output."""
@@ -706,7 +729,10 @@ class Partition:
             - WW3 documentation (https://github.com/NOAA-EMC/WW3).
 
         """
-        wspd, wdir, dpt = self._wind_and_depth(wspd, wdir, dpt)
+        # Falling back on dataset wind and depth would change the wind sea
+        # classification of existing code hence it is opt-in until v5.0
+        if OPTIONS[DATASET_TRANSFORMS]:
+            wspd, wdir, dpt = self._wind_and_depth(wspd, wdir, dpt)
         check_same_coordinates(wspd, wdir, dpt)
         # Smooth spectra for defining watershed boundaries
         if smooth:
@@ -969,7 +995,10 @@ class Partition:
               the size of the output.
 
         """
-        wspd, wdir, dpt = self._wind_and_depth(wspd, wdir, dpt)
+        # Falling back on dataset wind and depth would change the wind sea
+        # classification of existing hp01 code hence it is opt-in until v5.0
+        if OPTIONS[DATASET_TRANSFORMS]:
+            wspd, wdir, dpt = self._wind_and_depth(wspd, wdir, dpt)
         wind_kwargs = {"wspd": wspd, "wdir": wdir, "dpt": dpt}
         if method in ("ptm1", "ptm2"):
             check_same_coordinates(wspd, wdir, dpt)

--- a/wavespectra/specarray.py
+++ b/wavespectra/specarray.py
@@ -205,6 +205,11 @@ class SpecArray(object):
               This is the default behaviour for sum() in DataArray. Notice it
               converts masks, where the entire array is nan, into zero.
 
+        Returns:
+            - efth (DataArray): Frequency spectra, returned as a Dataset with
+              the non-spectral variables preserved when called from the
+              Dataset accessor.
+
         """
         if self.dir is not None:
             dsout = self.dd * self._obj.sum(dim=attrs.DIRNAME, skipna=skipna)
@@ -226,6 +231,11 @@ class SpecArray(object):
             - interpolate (bool): Interpolate spectra at frequency cutoffs they
               are not available in coordinates of input spectra.
             - rechunk (bool): Rechunk split dims so there is one single chunk.
+
+        Returns:
+            - efth (DataArray): Split spectra, returned as a Dataset with the
+              non-spectral variables preserved when called from the Dataset
+              accessor.
 
         """
         if fmax is not None and fmin is not None and fmax <= fmin:
@@ -265,7 +275,14 @@ class SpecArray(object):
         return other
 
     def to_energy(self):
-        """Convert spectra from energy density (m2/Hz/degree) into wave energy (m2)."""
+        """Convert spectra from energy density (m2/Hz/degree) into wave energy (m2).
+
+        Returns:
+            - energy (DataArray): Wave energy, returned as a Dataset with the
+              non-spectral variables preserved when called from the Dataset
+              accessor.
+
+        """
         energy = self._obj * self.df * self.dd
         set_spec_attributes(energy)
         energy.attrs.update(self._get_cf_attributes(attrs.ESPECNAME))
@@ -348,6 +365,11 @@ class SpecArray(object):
             - expr (str): expression to apply, e.g. '0.13*hs + 0.02'.
             - hs_min, hs_max, tp_min, tp_max, dpm_min, dpm_max (float): Ranges of hs,
                 tp and dpm over which the scaling defined by `expr` is applied.
+
+        Returns:
+            - efth (DataArray): Scaled spectra, returned as a Dataset with the
+              non-spectral variables preserved when called from the Dataset
+              accessor.
 
         """
         # Scale spectra by hs expression
@@ -820,7 +842,7 @@ class SpecArray(object):
 
         return xr.merge(params).rename(dict(zip(stats_dict.keys(), names)))
 
-    def rotate(self, angle) -> xr.DataArray:
+    def rotate(self, angle):
         """Rotate spectra.
 
         Args:
@@ -828,7 +850,9 @@ class SpecArray(object):
               and negative for counter-clockwise rotation.
 
         Returns:
-            - efth (DataArray): Rotated spectra.
+            - efth (DataArray): Rotated spectra, returned as a Dataset with the
+              non-spectral variables preserved when called from the Dataset
+              accessor.
 
         Note:
             - Directions are interpolated so that the rotated spectra have the same
@@ -847,7 +871,9 @@ class SpecArray(object):
             - dir_window (int): Rolling window size along `dir` dim.
 
         Returns:
-            - efth (DataArray): Smoothed spectra.
+            - efth (DataArray): Smoothed spectra, returned as a Dataset with
+              the non-spectral variables preserved when called from the
+              Dataset accessor.
 
         Note:
             - Window sizes must be odd to ensure symmetry.
@@ -864,7 +890,9 @@ class SpecArray(object):
             - maintain_m0 (bool): Ensure variance is conserved in interpolated spectra.
 
         Returns:
-            - dsi (DataArray): Regridded spectra.
+            - dsi (DataArray): Regridded spectra, returned as a Dataset with
+              the non-spectral variables preserved when called from the
+              Dataset accessor.
 
         Note:
             - All freq below lowest freq are interpolated assuming :math:`E_d(f=0)=0`.
@@ -882,7 +910,9 @@ class SpecArray(object):
             - maintain_m0 (bool): Ensure variance is conserved in interpolated spectra.
 
         Returns:
-            - dsi (DataArray): Regridded spectra.
+            - dsi (DataArray): Regridded spectra, returned as a Dataset with
+              the non-spectral variables preserved when called from the
+              Dataset accessor.
 
         """
         freq = getattr(other.spec, attrs.FREQNAME)
@@ -974,6 +1004,8 @@ class SpecArray(object):
             - Bunney et al. (2014).
 
         """
+        if isinstance(other, xr.Dataset):
+            other = other[attrs.SPECNAME]
         e0 = self.to_energy()
         e1 = other.spec.to_energy()
         ediff = np.sqrt(((e0 - e1) ** 2).sum(dim=self._spec_dims))

--- a/wavespectra/specdataset.py
+++ b/wavespectra/specdataset.py
@@ -5,13 +5,24 @@ import types
 import os
 import re
 import sys
+import warnings
 import xarray as xr
 
 from wavespectra.core.attributes import attrs
+from wavespectra.core.options import OPTIONS, DATASET_TRANSFORMS
 from wavespectra.core.select import sel_idw, sel_nearest, sel_bbox
 from wavespectra.core.utils import dataset_from_transform
 from wavespectra.partition.partition import Partition
 from wavespectra.specarray import SpecArray
+
+FUTURE_DATASET_TRANSFORMS = (
+    "`{name}` called from the Dataset accessor currently returns a DataArray "
+    "but will return a Dataset preserving the non-spectral variables in "
+    "wavespectra 5.0. Opt in to the future behaviour with "
+    "`wavespectra.set_options(dataset_transforms=True)`, or call it from the "
+    "DataArray accessor, e.g. `dset.efth.spec.{name}()`, to retain the "
+    "current behaviour and silence this warning."
+)
 
 here = os.path.dirname(os.path.abspath(__file__))
 
@@ -46,11 +57,13 @@ class SpecDataset(metaclass=Plugin):
     are attached as methods in this accessor class.
 
     Note:
-        - Methods that transform the spectral variable such as `interp`,
-          `smooth`, `split` or `oned` return a Dataset in this accessor with
-          the non-spectral variables from the underlying dataset preserved,
-          rather than the bare spectral DataArray returned by the SpecArray
-          accessor.
+        - When the `dataset_transforms` option is set with
+          `wavespectra.set_options(dataset_transforms=True)`, methods that
+          transform the spectral variable such as `interp`, `smooth`, `split`
+          or `oned` return a Dataset in this accessor with the non-spectral
+          variables from the underlying dataset preserved, rather than the
+          bare spectral DataArray returned by the SpecArray accessor. This
+          will become the default behaviour in wavespectra 5.0.
 
     """
 
@@ -115,11 +128,25 @@ class SpecDataset(metaclass=Plugin):
             setattr(self, method_name, method)
 
     def _dataset_output(self, method):
-        """Wrap spectral transform method to return a Dataset."""
+        """Wrap spectral transform method to return a Dataset.
+
+        The Dataset output only takes place if the `dataset_transforms`
+        option is set, otherwise a FutureWarning is emitted and the bare
+        spectral DataArray is returned.
+
+        """
 
         @functools.wraps(method)
         def wrapped(*args, **kwargs):
-            return dataset_from_transform(method(*args, **kwargs), self.dset)
+            dsout = method(*args, **kwargs)
+            if OPTIONS[DATASET_TRANSFORMS]:
+                return dataset_from_transform(dsout, self.dset)
+            warnings.warn(
+                FUTURE_DATASET_TRANSFORMS.format(name=method.__name__),
+                FutureWarning,
+                stacklevel=2,
+            )
+            return dsout
 
         return wrapped
 

--- a/wavespectra/specdataset.py
+++ b/wavespectra/specdataset.py
@@ -1,5 +1,6 @@
 """Wrapper around the xarray dataset."""
 
+import functools
 import types
 import os
 import re
@@ -8,6 +9,8 @@ import xarray as xr
 
 from wavespectra.core.attributes import attrs
 from wavespectra.core.select import sel_idw, sel_nearest, sel_bbox
+from wavespectra.core.utils import dataset_from_transform
+from wavespectra.partition.partition import Partition
 from wavespectra.specarray import SpecArray
 
 here = os.path.dirname(os.path.abspath(__file__))
@@ -42,7 +45,25 @@ class SpecDataset(metaclass=Plugin):
     Plugin functions defined in wavespectra/output/<module>
     are attached as methods in this accessor class.
 
+    Note:
+        - Methods that transform the spectral variable such as `interp`,
+          `smooth`, `split` or `oned` return a Dataset in this accessor with
+          the non-spectral variables from the underlying dataset preserved,
+          rather than the bare spectral DataArray returned by the SpecArray
+          accessor.
+
     """
+
+    _spectral_transforms = (
+        "interp",
+        "interp_like",
+        "oned",
+        "rotate",
+        "scale_by_hs",
+        "smooth",
+        "split",
+        "to_energy",
+    )
 
     def __init__(self, xarray_dset):
         self.dset = xarray_dset
@@ -62,6 +83,18 @@ class SpecDataset(metaclass=Plugin):
     def __repr__(self):
         return re.sub(r"<.+>", f"<{self.__class__.__name__}>", str(self.dset))
 
+    @property
+    def partition(self):
+        """Partition interface defined from the full dataset.
+
+        Wind speed, wind direction and depth variables in the dataset are
+        used as default arguments by the partitioning methods that require
+        them, and partitioned output is returned as a Dataset preserving the
+        non-spectral variables.
+
+        """
+        return Partition(self.dset)
+
     def _wrapper(self):
         """Wraper around SpecArray methods.
 
@@ -69,11 +102,26 @@ class SpecDataset(metaclass=Plugin):
         For example:
             self.spec.hs() becomes equivalent to self.efth.spec.hs()
 
+        Methods that transform the spectral variable are wrapped so they
+        return a Dataset that preserves the non-spectral variables.
+
         """
         for method_name in dir(self.dset[attrs.SPECNAME].spec):
-            if not method_name.startswith("_"):
-                method = getattr(self.dset[attrs.SPECNAME].spec, method_name)
-                setattr(self, method_name, method)
+            if method_name.startswith("_") or method_name == "partition":
+                continue
+            method = getattr(self.dset[attrs.SPECNAME].spec, method_name)
+            if method_name in self._spectral_transforms:
+                method = self._dataset_output(method)
+            setattr(self, method_name, method)
+
+    def _dataset_output(self, method):
+        """Wrap spectral transform method to return a Dataset."""
+
+        @functools.wraps(method)
+        def wrapped(*args, **kwargs):
+            return dataset_from_transform(method(*args, **kwargs), self.dset)
+
+        return wrapped
 
     def _check_and_stack_dims(self):
         """Ensure dimensions are suitable for dumping in some ascii formats.


### PR DESCRIPTION
## Summary

Transitional (4.x) release path for #166. This branch **includes** #166 and adds an opt-in switch on top, so the breaking change can be announced with a `FutureWarning` before 5.0 flips the default.

New `wavespectra.set_options` / `wavespectra.get_options` (xarray-style, usable globally or as a context manager) with a single option for now:

| `dataset_transforms` | Behaviour of `dset.spec.oned()` etc. and `dset.spec.partition.*` | Warning |
|---|---|---|
| `False` (default) | Current 4.x behaviour — bare spectral DataArray | `FutureWarning` pointing at the user's call site with both migration paths |
| `True` | The #166 behaviour — Dataset preserving non-spectral variables | none |

The DataArray accessor (`dset.efth.spec.*`) never changes and never warns — it is also the documented escape hatch to silence the warning without migrating.

## Wind/depth defaulting split

- `ptm1`, `ptm2`, `ptm4`: defaulting `wspd`/`wdir`/`dpt` from the dataset is purely additive (those args were previously required), so it is enabled unconditionally.
- `hp01`, `track`: defaulting changes the wind-sea classification of existing code that calls them without wind args, so it is gated behind the option.

## Other changes

- Internal callers are made flag-agnostic so library internals never emit the warning: octopus writer, `construct` partitioning, and `read_triaxys` (which now returns a Dataset as documented when regridding after a magnetic variation correction — previously it returned a DataArray in that path, a pre-existing inconsistency).
- Changelog restructured: the option and warning are under `4.7.0 (unreleased)`; `5.0.0 (unreleased)` now describes only the default flip.
- Tests: new `TestDefaultBehaviour` and `TestSetOptions` cover the flag-off path (DataArray returned, warning fired, values identical, no auto-wind for hp01) and the option mechanics; the tests exercising the future behaviour opt in via autouse fixtures. Suite runs with zero stray FutureWarnings.

## Merge / release strategy

- **Merge this PR (not #166 directly).** Since #166 is an ancestor of this branch, merging this marks #166 merged automatically and there is nothing to conflict — release as **4.7.0** with behaviour unchanged by default.
- The **5.0.0** release then becomes a tiny follow-up PR: flip the default to `True` (or remove the option), delete the warning, and re-flip the wording in the docs note.

## Testing

420 passed, 2 skipped. Verified by hand: default → DataArray + one FutureWarning per call site; opted-in → Dataset with `wspd`/`wdir`/`dpt` preserved, no warning; option restores correctly as a context manager; DataArray accessor silent under `-W error::FutureWarning`.