### PR TITLE
Document set_options and the dataset_transforms behaviour change

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -20,6 +20,27 @@ Wavespectra accessors
 \* The two accessors are attached to the respective xarray objects via the `spec` namespace.
 
 
+Options
+-------
+
+Package-level options can be set globally or within a context block. The
+``dataset_transforms`` option opts in to the future behaviour (default from
+wavespectra 5.0) where methods that transform the spectral variable such as
+:py:meth:`SpecArray.interp`, :py:meth:`SpecArray.smooth`,
+:py:meth:`SpecArray.split`, :py:meth:`SpecArray.oned` and the partitioning
+methods return a Dataset preserving the non-spectral variables when called
+from the Dataset accessor, instead of a bare spectral DataArray. Until then,
+calling these methods from the Dataset accessor without the option set emits
+a ``FutureWarning``.
+
+.. autosummary::
+   :nosignatures:
+   :toctree: generated/
+
+   set_options
+   get_options
+
+
 SpecArray
 ---------
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -182,6 +182,15 @@ Interpolate
 -----------
 A custom interpolation method takes care of the cyclic nature of the wave direction.
 
+.. note::
+    Methods that transform the spectral variable such as ``interp``, ``smooth``,
+    ``split`` and ``oned`` will return a Dataset preserving the non-spectral
+    variables when called from the Dataset accessor in wavespectra 5.0, instead
+    of the bare spectral DataArray currently returned. Opt in to the future
+    behaviour with ``wavespectra.set_options(dataset_transforms=True)``, or call
+    these methods from the DataArray accessor, e.g. ``dset.efth.spec.oned()``,
+    to retain the current return type and silence the ``FutureWarning``.
+
 .. ipython:: python
     :okwarning:
 


### PR DESCRIPTION
Follow-up to #167: adds `set_options` / `get_options` to the API reference with a short description of the `dataset_transforms` option, and a note in the quickstart where the transform methods are introduced explaining the upcoming return-type change, how to opt in, and how to silence the FutureWarning.