### PR TITLE
Slice tab file data at the times actually read in read_swans

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -62,10 +62,20 @@ Bug Fixes
 * ``read_triaxys`` now returns a Dataset as documented when reading with
   ``magnetic_variation`` and ``regrid_dir=True`` (previously it returned a
   DataArray in that case).
+* ``read_swans`` now appends the winds and depth from tab files when the
+  ``ntimes`` option is used, previously the tab data were dropped with a
+  warning since they were not sliced consistently with the spectra
+  (`#51 <https://github.com/wavespectra/wavespectra/issues/51>`_).
 
 Internal Changes
 ----------------
 * ``rmse`` now accepts a Dataset in the ``other`` argument.
+* The ``ndays`` and ``ntimes`` options of ``read_swans`` now share a common
+  early-stopping reading loop so ``ndays`` also stops parsing each file once
+  the requested period is read, and the two options can be combined with
+  whichever limit is reached first stopping the reading. The ``ndays`` cutoff
+  now keeps records up to the exact end of the period instead of the record
+  nearest to it.
 
 4.6.0 (2026-07-08)
 ___________________

--- a/tests/io/test_swan_ascii.py
+++ b/tests/io/test_swan_ascii.py
@@ -32,6 +32,41 @@ def test_read_swans(dset):
     assert dset.time.size > ds.time.size
 
 
+@pytest.mark.parametrize(
+    "kwargs, ntimes_expected", [({"ntimes": 3}, 3), ({"ndays": 1}, 2)]
+)
+def test_read_swans_sliced_times_keep_tab(kwargs, ntimes_expected):
+    """Winds and depth from tab files are appended when slicing times, see #51."""
+    full = read_swans([FILENAME])
+    ds = read_swans([FILENAME], **kwargs)
+    assert ds.time.size == ntimes_expected
+    for v in ["wspd", "wdir", "dpt"]:
+        assert v in ds.data_vars
+        xr.testing.assert_allclose(ds[v], full[v].isel(time=slice(0, ds.time.size)))
+    xr.testing.assert_allclose(ds.efth, full.efth.isel(time=slice(0, ds.time.size)))
+
+
+def test_read_swans_ndays_and_ntimes():
+    """Whichever of the ndays and ntimes limits is reached first stops the reading."""
+    ds = read_swans([FILENAME], ndays=2, ntimes=1)
+    assert ds.time.size == 1
+    ds = read_swans([FILENAME], ndays=1, ntimes=99)
+    assert ds.time.size == 2
+    assert "wspd" in ds.data_vars
+
+
+def test_read_swans_ntimes_more_than_available(dset):
+    """All available times are read when ntimes exceeds the record number."""
+    ds = read_swans([FILENAME], ntimes=99)
+    assert ds.time.size == dset.time.size
+
+
+def test_read_swans_ndays_longer_than_file():
+    """An exception is raised if the file does not span the requested period."""
+    with pytest.raises(OSError):
+        read_swans([FILENAME], ndays=30)
+
+
 def test_read_hotswan():
     """Test that swan hotstart file is read as a grid."""
     filename = FILENAME.parent / "swanhot.spec"

--- a/wavespectra/input/swan.py
+++ b/wavespectra/input/swan.py
@@ -176,8 +176,11 @@ def read_swans(
 
     Args:
         - fileglob (str, list): glob pattern specifying files to read.
-        - ndays (float): number of days to keep from each file, choose None to
-          keep entire period.
+        - ndays (float): number of days to keep from the start of each file,
+          choose None to keep the entire period. Useful for constructing
+          continuous timeseries from files of overlapping forecast cycles.
+          Reading stops once the period is read and an exception is raised
+          if a file does not span the requested period.
         - int_freq (ndarray, bool): frequency array for interpolating onto:
 
             - ndarray: 1d array specifying frequencies to interpolate onto.
@@ -192,8 +195,11 @@ def read_swans(
             - False: No interpolation performed in direction space.
 
         - dirorder (bool): if True ensures directions are sorted.
-        - ntimes (int): use it to read only specific number of times, useful
-          for checking headers only.
+        - ntimes (int): number of times to read from the start of each file,
+          choose None to read all times. Reading stops early once the records
+          are read which makes it useful for quickly inspecting the first few
+          records of large files. Can be combined with ndays, whichever limit
+          is reached first stops the reading.
 
     Returns:
         - dset (SpecDataset): spectra dataset object read from file with
@@ -207,6 +213,8 @@ def read_swans(
           have same number of sites.
         - Either all or none of the spectra in fileglob must have tabfile
           associated to provide wind/depth data.
+        - Winds and depth from tab files are sliced at the times actually
+          read when the ndays or ntimes options are used.
         - Concatenation is done with numpy arrays for efficiency.
 
     """
@@ -249,16 +257,40 @@ def read_swans(
         freqs = swanfile.freqs
         dirs = swanfile.dirs
 
-        if ntimes is None:
-            spec_list = [s for s in swanfile.readall()]
-        else:
-            spec_list = [swanfile.read() for itime in range(ntimes)]
+        # Read spectra records, stopping early once ntimes records or ndays
+        # worth of times have been read so the rest of the file is not parsed
+        spec_list = []
+        tend = None
+        truncated = False
+        while ntimes is None or len(spec_list) < ntimes:
+            sset = swanfile.read()
+            if not sset:
+                break
+            if ndays is not None:
+                if tend is None:
+                    tend = times[0] + datetime.timedelta(days=ndays)
+                if times[-1] > tend:
+                    # Ignore the time parsed beyond the period and stop reading
+                    times.pop()
+                    truncated = True
+                    break
+            spec_list.append(sset)
 
-        # Read tab files for winds / depth
+        # Ensure file spans the requested period unless ntimes stopped first
+        ntimes_reached = ntimes is not None and len(spec_list) == ntimes
+        if tend is not None and not truncated and not ntimes_reached:
+            if times[-1] < tend:
+                raise OSError(
+                    "Times in %s does not extend for %0.2f days" % (filename, ndays)
+                )
+
+        # Read tab files for winds / depth, slicing at the times actually read
+        tab = pd.DataFrame()
         if swanfile.is_tab:
             try:
                 tab = read_tab(swanfile.tabfile).rename(columns={"dep": attrs.DEPNAME})
-                if len(swanfile.times) == tab.index.size:
+                if isinstance(times, list) and set(times).issubset(tab.index):
+                    tab = tab.loc[times]
                     if "X-wsp" in tab and "Y-wsp" in tab:
                         tab[attrs.WSPDNAME], tab[attrs.WDIRNAME] = uv_to_spddir(
                             tab["X-wsp"], tab["Y-wsp"], coming_from=True
@@ -277,23 +309,10 @@ def read_swans(
                     )
                 ]
             except Exception as exc:
+                tab = pd.DataFrame()
                 warnings.warn(
                     f"Cannot parse depth and winds from {swanfile.tabfile}:\n{exc}"
                 )
-        else:
-            tab = pd.DataFrame()
-
-        # Shrinking times
-        if ndays is not None:
-            tend = times[0] + datetime.timedelta(days=ndays)
-            if tend > times[-1]:
-                raise OSError(
-                    "Times in %s does not extend for %0.2f days" % (filename, ndays)
-                )
-            iend = times.index(min(times, key=lambda d: abs(d - tend)))
-            times = times[0 : iend + 1]
-            spec_list = spec_list[0 : iend + 1]
-            tab = tab.loc[times[0] : tend] if tab is not None else tab
 
         spec_list = flatten_list(spec_list, [])
 


### PR DESCRIPTION
Fixes #51.

## Root cause

`SwanSpecFile.times` is populated lazily — each `read()` call appends one timestamp. With `ntimes` set, only the first n records are read so `swanfile.times` has n entries while `read_tab` reads the full tab file; the consistency guard (`len(swanfile.times) == tab.index.size`) then failed and silently dropped `wspd`/`wdir`/`dpt` with the "times not consistent" warning.

## Changes

All confined to `read_swans` — `SwanSpecFile`, `read_swan` and `to_swan` are untouched:

- `ndays` and `ntimes` now share a single early-stopping read loop built on the existing `SwanSpecFile.read()` primitive. `ntimes` semantics are unchanged; `ndays` gains the early-stop I/O benefit (it previously parsed the whole file before truncating).
- The tab data are sliced at the times actually read (`tab.loc[times]` after a membership check), so both options keep winds and depth. The membership check is also more correct than the old length comparison — it validates the actual timestamps rather than just the counts.
- The two options can now be combined; whichever limit is reached first stops the reading (previously combining them raised a misleading "does not extend for N days" error).
- `ntimes` larger than the number of records now reads all available records (previously it produced a broken spectra list).
- Behaviour note: the `ndays` cutoff now keeps records up to the *exact* end of the period instead of the record nearest to it — identical results whenever the output interval divides the period (the common case), slightly stricter otherwise.
- Docstrings rewritten to state the distinct purposes of the two options (`ndays`: per-cycle duration truncation for overlapping forecast cycles; `ntimes`: cheap record-count peek).

## Testing

New tests use the existing `swanfile.spec`/`swanfile.tab` fixtures: `wspd`/`wdir`/`dpt` presence and value-consistency under `ntimes` and `ndays`, the combined limits, `ntimes` beyond the record count, and the `ndays`-longer-than-file error. Full suite: 425 passed, 2 skipped.