### PR TITLE
docs: add recipe for sorting partitions and fix docs build breakage

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -417,7 +417,7 @@ Partitioning
 Stats
 ~~~~~
 * Method for non-linear gaussian fit in SpecArray by `Paul Branson`_
-  (`PR1 <https://github.com/oceanum/wavespectra/pull/3>`_).
+  (`PR3 <https://github.com/oceanum/wavespectra/pull/3>`_).
 * Methods to calculate stokes drift and the mean squared slope by `Paul Branson`_
   (`PR1 <https://github.com/oceanum/wavespectra/pull/1>`_).
 * Gaussian frequency width method `gw` in SpecArray.
@@ -592,7 +592,7 @@ ___________________
 
 Internal Changes
 ----------------
-* Redefine packaging via pyproject.toml to conform to PEP517/518 (`PR77 <https://github.com/wavespectra/wavespectra/pull/87>`_).
+* Redefine packaging via pyproject.toml to conform to PEP517/518 (`PR87 <https://github.com/wavespectra/wavespectra/pull/87>`_).
 * All packaging metadata removed from setup.py and moved to pyproject.toml. The
   setup.py file is now only used to build the Fortran module.
 * Removed the MANIFEST.in file, package data now handled in pyproject.toml.
@@ -799,7 +799,7 @@ Internal Changes
 Bug Fixes
 ---------
 * Fix bug in sel with `"nearest"` option.
-* Ensure last time chunk is written in `to_swan`_ when the dataset time size is not divisible by ntime (`GH20 <https://github.com/wavespectra/wavespectra/issues/24>`_).
+* Ensure last time chunk is written in `to_swan`_ when the dataset time size is not divisible by ntime (`GH24 <https://github.com/wavespectra/wavespectra/issues/24>`_).
 
 
 .. _`to_netcdf`: https://github.com/wavespectra/wavespectra/blob/master/wavespectra/output/netcdf.py

--- a/docs/gallery/plot_spectra_timeseries.py
+++ b/docs/gallery/plot_spectra_timeseries.py
@@ -14,8 +14,8 @@ from wavespectra import read_ww3
 fig = plt.figure(figsize=(8, 4))
 
 dset = read_ww3("../_static/ww3file.nc")
-ds = dset.isel(site=0).spec.split(fmax=0.18)
-ds = ds.efth.spec.oned().rename({"freq": "period"})
+ds = dset.isel(site=0).efth.spec.split(fmax=0.18)
+ds = ds.spec.oned().rename({"freq": "period"})
 ds = ds.assign_coords({"period": 1 / ds.period})
 ds.period.attrs.update({"standard_name": "sea_surface_wave_period", "units": "s"})
 p = ds.plot.contourf(

--- a/docs/gallery/plot_split_sea_swell.py
+++ b/docs/gallery/plot_split_sea_swell.py
@@ -13,8 +13,8 @@ from wavespectra import read_ww3
 dset = read_ww3("../_static/ww3file.nc")
 
 fcut = 1 / 8
-sea = dset.spec.split(fmin=fcut)
-swell = dset.spec.split(fmax=fcut)
+sea = dset.efth.spec.split(fmin=fcut)
+swell = dset.efth.spec.split(fmax=fcut)
 
 plt.figure(figsize=(8, 4.5))
 p1 = dset.spec.hs().isel(site=0).plot(label="Full spectrum", marker="o")

--- a/docs/partitioning.rst
+++ b/docs/partitioning.rst
@@ -467,6 +467,36 @@ Against the tracked partitions:
     plt.draw()
 
 
+Sorting partitions
+__________________
+
+The watershed methods sort the swell partitions by descending significant wave height,
+following the convention used in the WW3 and SWAN models. Notice the wave height
+ranking also defines which partitions are retained when there are more partitions in a
+spectrum than slots requested with the `swells` argument (`parts` in `ptm3`), so a
+significant but small long-period swell could be excluded from the output if only a
+few partitions are requested. Set the argument to None to keep all detected
+partitions, then reorder them by any parameter calculated from the partitioned
+spectra. The example below sorts the partitions of each spectrum by descending peak
+period, with null partitions kept at the end:
+
+.. ipython:: python
+    :okwarning:
+
+    dset = read_wwm("_static/wwmfile.nc")
+    dspart = dset.spec.partition.ptm3(parts=None)
+    tp = dspart.spec.tp().load()
+    inds = (-tp).fillna(np.inf).argsort(axis=tp.get_axis_num("part"))
+    dsort = dspart.isel(part=inds.drop_vars("part"))
+    tp.isel(site=0).values
+    dsort.spec.tp().isel(site=0).values
+
+Alternatively, consider the `hp01` method to combine partition fragments belonging to
+the same wave system so that significant swells emerge within fewer partitions, and
+the `min_duration` argument of the `track` method with `systems=True` to exclude
+short-lived, spurious wave systems from the output.
+
+
 .. _`WAVEWATCHIII`: https://github.com/NOAA-EMC/WW3
 .. _`Hanson and Phillips (2001)`: https://journals.ametsoc.org/view/journals/atot/18/2/1520-0426_2001_018_0277_aaoosd_2_0_co_2.xml
 .. _`Hanson et al. (2009)`: https://journals.ametsoc.org/view/journals/atot/26/8/2009jtecho650_1.xml

--- a/docs/plotting.rst
+++ b/docs/plotting.rst
@@ -232,7 +232,7 @@ The radii extents are controlled from `rmin` and `rmax` parameters:
 Plotting parameters from xarray
 -------------------------------
 
-Wavespectra allows passing some parameters from the functions wrapped from xarray such as `contourf <http://xarray.pydata.org/en/stable/generated/xarray.plot.contourf.html>`_ 
+Wavespectra allows passing some parameters from the functions wrapped from xarray such as `contourf`_
 (excluding some that are manipulated in wavespectra such as `ax`, `x` and others):
 
 .. ipython:: python

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -267,7 +267,7 @@ Plotting Hovmoller diagrams of frequency spectra time series can be done in only
     @suppress
     plt.figure(figsize=(8, 4))
 
-    ds = dset.isel(site=0).spec.split(fmax=0.18).efth.spec.oned().rename({"freq": "period"})
+    ds = dset.isel(site=0).efth.spec.split(fmax=0.18).spec.oned().rename({"freq": "period"})
     ds = ds.assign_coords({"period": 1 / ds.period})
     ds.period.attrs.update({"standard_name": "sea_surface_wave_period", "units": "s"})
 


### PR DESCRIPTION
## Summary

Two docs changes:

**Sorting partitions recipe (relates to #154)**

New "Sorting partitions" section on the partitioning page showing how to reorder watershed partitions by an arbitrary parameter (peak period in the example). It also documents the subtlety underlying #154: the default Hs ranking is not only presentational — it defines *which* partitions are retained when `swells`/`parts` is smaller than the number detected, so a significant long-period swell can silently fall off the output. The recipe recommends `swells=None` to avoid dropping anything before re-sorting, and points at `hp01` and `track(systems=True, min_duration=...)` as complementary tools.

**Docs build fixes**

The docs build on main is currently broken: a quickstart cell and the `plot_spectra_timeseries.py` gallery script (touched in #168) access `.efth` on the output of `spec.split()` called from the Dataset accessor, which still returns a DataArray until the `dataset_transforms` option becomes the default → `AttributeError` at build time, and RTD has `fail_on_warning` enabled. Fixed by calling `split` from the DataArray accessor (flag-agnostic). Also switched `plot_split_sea_swell.py` to the DataArray accessor so no `FutureWarning` is rendered in the gallery output.

## Verification

- Full local docs build with `sphinx -W --keep-going` passes warning-clean.
- The recipe snippet was run standalone under both the default flag (DataArray output) and `dataset_transforms=True` (Dataset output), and with `FutureWarning` raised as error for the fixed cells.