### PR TITLE
Build wheels for Python 3.14

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     -

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -115,6 +115,53 @@ To run a subset of tests::
 $ pytest tests/test_specarray.py
 
 
+Packaging Notes
+---------------
+
+Some of the packaging settings in ``pyproject.toml`` are not self-explanatory,
+the reasoning behind them is recorded here.
+
+``[project] dependencies``
+    ``numpy`` is declared explicitly because the compiled ``specpart``
+    extension links the numpy C API, even though numpy would also be installed
+    transitively through ``scipy`` and ``xarray``.
+
+``[tool.setuptools.packages.find] include``
+    Packages are listed explicitly so that stray top-level directories created
+    at build time, such as cibuildwheel's ``wheelhouse``, do not break the
+    flat-layout auto-discovery.
+
+``[tool.cibuildwheel] build``
+    The CPython versions to build wheels for, which should be kept in sync
+    with the supported range in the classifiers and in the test matrix of the
+    testing workflow. Free-threaded builds use separate ``cp3XXt-*``
+    identifiers so they are not built unless they are listed here.
+
+``[tool.cibuildwheel] archs``
+    64-bit only. 32-bit Windows wheels would be built by default but core
+    dependencies such as matplotlib no longer ship win32 wheels to test the
+    built wheels against.
+
+``[tool.cibuildwheel] skip``
+    musl-based linux wheels are not built, they can be added if there is
+    demand for them.
+
+``[tool.cibuildwheel] test-requires`` and ``test-command``
+    Every built wheel is tested by running the partition test module, which
+    exercises the compiled ``specpart`` extension end to end. This requires
+    netCDF4 to be available for the wheels of every Python version built.
+
+``[tool.pytest.ini_options] filterwarnings``
+    netCDF4-python sets the ``shape`` attribute on numpy arrays, which numpy
+    2.5 deprecated. It surfaces through the xarray netCDF4 backend whenever a
+    netcdf file is written and is a third-party issue, nothing to fix in
+    wavespectra.
+
+``[tool.ruff.lint] extend-select``
+    B015 and B018 flag comparisons and expressions whose result is discarded,
+    which in tests almost always means a forgotten ``assert``.
+
+
 Deploying
 ---------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -33,9 +33,20 @@ Breaking Changes
 * The ``wspd``, ``wdir`` and ``dpt`` arguments of the ``hp01`` and ``track``
   partitioning methods now default to the variables with those names in the
   underlying dataset when partitioning from a Dataset.
+* Support for Python 3.9 is removed, the minimum supported version is now
+  Python 3.10. This was announced in 4.8.0.
 
 4.8.0 (unreleased)
 ___________________
+
+Deprecations
+------------
+* Support for Python 3.9 is deprecated and will be removed in wavespectra 5.0,
+  when the minimum supported version becomes Python 3.10. Python 3.9 reached
+  its end of life in October 2025 and current releases of the core
+  dependencies no longer support it. Environments running Python 3.9 will keep
+  working: pip installs the latest wavespectra compatible with the running
+  interpreter, so they will resolve to the 4.x series rather than fail.
 
 Internal Changes
 ----------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -34,6 +34,16 @@ Breaking Changes
   partitioning methods now default to the variables with those names in the
   underlying dataset when partitioning from a Dataset.
 
+4.8.0 (unreleased)
+___________________
+
+Internal Changes
+----------------
+* Binary wheels are now built for Python 3.14.
+* ``numpy`` is now declared explicitly as a runtime dependency. It was already
+  required by the compiled ``specpart`` extension through the numpy C API and
+  was being installed transitively by other dependencies.
+
 4.7.0 (2026-07-09)
 ___________________
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,6 @@ dependencies = [
     "click",
     "dask",
     "matplotlib",
-    # Linked by the compiled specpart extension via the numpy C API, so it is
-    # declared explicitly rather than relying on it arriving transitively.
     "numpy",
     "python-dateutil",
     "pyyaml",
@@ -103,8 +101,6 @@ docs = [
 ]
 
 [tool.setuptools.packages.find]
-# Explicit include so stray top-level directories created at build time
-# (e.g. cibuildwheel's wheelhouse/) don't break flat-layout auto-discovery.
 include = ["wavespectra*"]
 
 [tool.setuptools.package-data]
@@ -116,15 +112,9 @@ include = ["wavespectra*"]
 version = {attr = "wavespectra.__version__"}
 
 [tool.cibuildwheel]
-# CPython versions matching the supported range in the classifiers.
 build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
-# 64-bit only: 32-bit Windows wheels would be built by default, but core
-# dependencies (e.g. matplotlib) no longer ship win32 wheels to test against.
 archs = ["auto64"]
-# Skip musl-based linux; can be added later if there is demand.
 skip = ["*-musllinux*"]
-# Test every built wheel by running the partition test module, which
-# exercises the compiled specpart extension end to end.
 test-requires = ["pytest", "netCDF4"]
 test-command = "pytest {project}/tests/test_partition.py -q"
 build-verbosity = 1
@@ -132,9 +122,6 @@ build-verbosity = 1
 [tool.pytest.ini_options]
 norecursedirs = [".*", "build", "dist", "CVS", "_darcs", "{arch}", "*.egg", "venv", "broken"]
 filterwarnings = [
-    # netCDF4-python sets the .shape attribute on numpy arrays, which numpy
-    # 2.5 deprecated; it surfaces through xarray's netCDF4 backend whenever a
-    # netCDF file is written. Third-party issue, nothing to fix in wavespectra.
     "ignore:Setting the shape on a NumPy array has been deprecated:DeprecationWarning",
 ]
 
@@ -147,8 +134,6 @@ indent-style = "space"
 line-ending = "auto"
 
 [tool.ruff.lint]
-# B015/B018: flag comparisons/expressions whose result is discarded, which in
-# tests almost always means a forgotten `assert`.
 extend-select = ["B015", "B018"]
 
 [tool.ruff.lint.extend-per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,12 +30,16 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 requires-python = ">=3.9"
 dependencies = [
     "click",
     "dask",
     "matplotlib",
+    # Linked by the compiled specpart extension via the numpy C API, so it is
+    # declared explicitly rather than relying on it arriving transitively.
+    "numpy",
     "python-dateutil",
     "pyyaml",
     "sortedcontainers",
@@ -113,7 +117,7 @@ version = {attr = "wavespectra.__version__"}
 
 [tool.cibuildwheel]
 # CPython versions matching the supported range in the classifiers.
-build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*"]
+build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
 # 64-bit only: 32-bit Windows wheels would be built by default, but core
 # dependencies (e.g. matplotlib) no longer ship win32 wheels to test against.
 archs = ["auto64"]


### PR DESCRIPTION
Adds CPython 3.14 to the wheel build matrix and declares `numpy` explicitly as a runtime dependency.

## Python 3.14 wheels

- `cp314-*` added to the `[tool.cibuildwheel]` build selectors and the matching classifier added to `[project]`.
- No workflow change needed: cibuildwheel 4.1.0 (already pinned in `python-publish.yml`) ships CPython 3.14; 3.14 support predates the 4.0 release, which added 3.15 as a *prerelease*.
- The `specpart` C extension uses only `PyModuleDef`/`PyModule_Create` and the numpy C API, so it compiles unchanged.
- All dependencies publish cp314 wheels (numpy 2.5.1, scipy 1.18.0, matplotlib 3.11.1, pandas 3.0.3, netCDF4 1.7.4). netCDF4 matters in particular because `test-requires` installs it to run `tests/test_partition.py` against every built wheel.
- Free-threaded builds are unaffected: `cp314-*` does not match the `cp314t-*` identifiers, so they remain opt-in.

## numpy dependency

`numpy` was only ever installed transitively via scipy/xarray, despite the compiled extension linking the numpy C API. Now declared explicitly.

## Verification

The wheel-building job runs on this PR (the `paths` filter covers `pyproject.toml`), so the cp314 build and its test step are exercised across all five runners before release.